### PR TITLE
Upgrade fix for API 2025.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,6 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     intellijPlatform {
         clion(runIdeVersion)
-        bundledPlugin("com.intellij.clion")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ val runIdeType: String = when (2) {
     else -> "IC"
 }
 
-val runIdeVersion = "2025.1"
+val runIdeVersion = "2025.2"
 
 plugins {
     id("java")
@@ -82,7 +82,7 @@ intellijPlatform{
                     IntelliJPlatformType.IntellijIdeaCommunity
                 )
                 sinceBuild = "243"
-                untilBuild = "251.*"
+                untilBuild = "252.*"
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,43 +6,11 @@ fun properties(key: String) = project.findProperty(key).toString()
 val localChangeNotes: String = file("${projectDir}/change-notes.html").readText(Charsets.UTF_8)
 val localDescription: String = file("${projectDir}/description.html").readText(Charsets.UTF_8)
 
-val type = mapOf(
-    "IC" to "ideaIC",
-    "IU" to "ideaIU",
-    "CL" to "clion",
-    "PY" to "pycharmPY"
-)
-
-/*
-* Best practice:
-* Use CL for both building and running.
-* If you lack a license, use CLI for building and IC for running.
-* Specify the ideDir path as needed.
-* */
-
-val buildIdeType: String = when (2) {
-    0 -> "IC" // SSH-related functions cannot be built by the Community version.
-    1 -> "IU" // To build with Ultimate version does not require a license.
-    2 -> "CL" // C/C++ intellij-sense is included.
-    3 -> "PY"
-    else -> "IC"
-}
-
-val buildIdeVersion = "2025.1"
-
-val runIdeType: String = when (2) {
-    0 -> "IC" // You can build with the Ultimate version, but run with the Community version.
-    1 -> "IU" // It may require a license to run with the Ultimate version.
-    2 -> "CL"  // It includes C/C++ related functions, along with functions in the Ultimate version.
-    3 -> "PY"
-    else -> "IC"
-}
-
 val runIdeVersion = "2025.2"
 
 plugins {
     id("java")
-    id("org.jetbrains.intellij.platform") version "2.5.0"
+    id("org.jetbrains.intellij.platform") version "2.7.2"
     id("org.jetbrains.kotlin.jvm") version "2.1.0"
     id("org.jetbrains.changelog") version "2.2.0"
     kotlin("plugin.serialization") version "2.1.0"
@@ -78,8 +46,6 @@ intellijPlatform{
             select {
                 types = listOf(
                     IntelliJPlatformType.CLion,
-                    IntelliJPlatformType.IntellijIdeaUltimate,
-                    IntelliJPlatformType.IntellijIdeaCommunity
                 )
                 sinceBuild = "243"
                 untilBuild = "252.*"
@@ -101,7 +67,7 @@ dependencies {
     testImplementation("io.mockk:mockk:1.13.12")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     intellijPlatform {
-        create(runIdeType, runIdeVersion)
+        clion(runIdeVersion)
         bundledPlugin("com.intellij.clion")
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginVersion=1.4.6
 pluginSinceBuild=243.21565.193
-pluginUntilBuild=251.*
+pluginUntilBuild=252.*
 
 # Opt-out flag for bundling Kotlin standard library.
 # See https://kotlinlang.org/docs/reference/using-gradle.html#dependency-on-the-standard-library for details.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,23 +1,6 @@
 pluginVersion=1.4.6
-pluginSinceBuild=243.21565.193
+pluginSinceBuild=243
 pluginUntilBuild=252.*
-
-# Opt-out flag for bundling Kotlin standard library.
-# See https://kotlinlang.org/docs/reference/using-gradle.html#dependency-on-the-standard-library for details.
-kotlin.stdlib.default.dependency=false
-
-# proxy
-# systemProp.http.proxyHost=127.0.0.1
-# systemProp.http.proxyPort=7890
-# systemProp.https.proxyHost=127.0.0.1
-# systemProp.https.proxyPort=7890
-
-# testing in clion
-testInClion=false
-
 
 org.gradle.warning.mode=all
 kotlin.daemon.jvmargs=-Xmx2048m
-
-# Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 8.5

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/kotlin/io/xmake/actions/BuildAction.kt
+++ b/src/main/kotlin/io/xmake/actions/BuildAction.kt
@@ -1,7 +1,7 @@
 package io.xmake.actions
 
-import com.intellij.execution.process.ProcessAdapter
 import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
@@ -27,7 +27,7 @@ class BuildAction : AnAction() {
             val xmakeConfiguration = project.xmakeConfiguration
             if (xmakeConfiguration.changed) {
                 SystemUtils.runvInConsole(project, xmakeConfiguration.configurationCommandLine)
-                    ?.addProcessListener(object : ProcessAdapter() {
+                    ?.addProcessListener(object : ProcessListener {
                         override fun processTerminated(e: ProcessEvent) {
                             SystemUtils.runvInConsole(project, xmakeConfiguration.buildCommandLine, false, true, true)
                         }

--- a/src/main/kotlin/io/xmake/actions/CleanAction.kt
+++ b/src/main/kotlin/io/xmake/actions/CleanAction.kt
@@ -1,7 +1,7 @@
 package io.xmake.actions
 
-import com.intellij.execution.process.ProcessAdapter
 import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
@@ -27,7 +27,7 @@ class CleanAction : AnAction() {
             val xmakeConfiguration = project.xmakeConfiguration
             if (xmakeConfiguration.changed) {
                 SystemUtils.runvInConsole(project, xmakeConfiguration.configurationCommandLine)
-                    ?.addProcessListener(object : ProcessAdapter() {
+                    ?.addProcessListener(object : ProcessListener {
                         override fun processTerminated(e: ProcessEvent) {
                             SystemUtils.runvInConsole(project, xmakeConfiguration.cleanCommandLine, false, false, true)
                         }

--- a/src/main/kotlin/io/xmake/actions/RebuildAction.kt
+++ b/src/main/kotlin/io/xmake/actions/RebuildAction.kt
@@ -1,7 +1,7 @@
 package io.xmake.actions
 
-import com.intellij.execution.process.ProcessAdapter
 import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
@@ -27,7 +27,7 @@ class RebuildAction : AnAction() {
             val xmakeConfiguration = project.xmakeConfiguration
             if (xmakeConfiguration.changed) {
                 SystemUtils.runvInConsole(project, xmakeConfiguration.configurationCommandLine)
-                    ?.addProcessListener(object : ProcessAdapter() {
+                    ?.addProcessListener(object : ProcessListener {
                         override fun processTerminated(e: ProcessEvent) {
                             SystemUtils.runvInConsole(project, xmakeConfiguration.rebuildCommandLine, false, true, true)
                         }

--- a/src/main/kotlin/io/xmake/actions/RunAction.kt
+++ b/src/main/kotlin/io/xmake/actions/RunAction.kt
@@ -1,7 +1,7 @@
 package io.xmake.actions
 
-import com.intellij.execution.process.ProcessAdapter
 import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
@@ -27,7 +27,7 @@ class RunAction : AnAction() {
             val xmakeConfiguration = project.xmakeConfiguration
             if (xmakeConfiguration.changed) {
                 SystemUtils.runvInConsole(project, xmakeConfiguration.configurationCommandLine)
-                    ?.addProcessListener(object : ProcessAdapter() {
+                    ?.addProcessListener(object : ProcessListener {
                         override fun processTerminated(e: ProcessEvent) {
                             SystemUtils.runvInConsole(
                                 project,

--- a/src/main/kotlin/io/xmake/actions/UpdateCmakeListsAction.kt
+++ b/src/main/kotlin/io/xmake/actions/UpdateCmakeListsAction.kt
@@ -1,7 +1,7 @@
 package io.xmake.actions
 
-import com.intellij.execution.process.ProcessAdapter
 import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
@@ -28,7 +28,7 @@ class UpdateCmakeListsAction : AnAction() {
             val xmakeConfiguration = project.xmakeConfiguration
             if (xmakeConfiguration.changed) {
                 SystemUtils.runvInConsole(project, xmakeConfiguration.configurationCommandLine)
-                    ?.addProcessListener(object : ProcessAdapter() {
+                    ?.addProcessListener(object : ProcessListener {
                         override fun processTerminated(e: ProcessEvent) {
                             syncBeforeFetch(project, project.activatedToolkit!!)
 
@@ -39,7 +39,7 @@ class UpdateCmakeListsAction : AnAction() {
                                 true,
                                 true
                             )?.addProcessListener(
-                                object : ProcessAdapter() {
+                                object : ProcessListener {
                                     override fun processTerminated(e: ProcessEvent) {
                                         fetchGeneratedFile(project, project.activatedToolkit!!, "CMakeLists.txt")
                                         // Todo: Reload from disks after download from remote.
@@ -52,7 +52,7 @@ class UpdateCmakeListsAction : AnAction() {
             } else {
                 SystemUtils.runvInConsole(project, xmakeConfiguration.updateCmakeListsCommandLine, false, true, true)
                     ?.addProcessListener(
-                        object : ProcessAdapter() {
+                        object : ProcessListener{
                             override fun processTerminated(e: ProcessEvent) {
                                 fetchGeneratedFile(project, project.activatedToolkit!!, "CMakeLists.txt")
                             }

--- a/src/main/kotlin/io/xmake/actions/UpdateCompileCommandsAction.kt
+++ b/src/main/kotlin/io/xmake/actions/UpdateCompileCommandsAction.kt
@@ -1,7 +1,7 @@
 package io.xmake.actions
 
-import com.intellij.execution.process.ProcessAdapter
 import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
@@ -28,7 +28,7 @@ class UpdateCompileCommandsAction : AnAction() {
             val xmakeConfiguration = project.xmakeConfiguration
             if (xmakeConfiguration.changed) {
                 SystemUtils.runvInConsole(project, xmakeConfiguration.configurationCommandLine)
-                    ?.addProcessListener(object : ProcessAdapter() {
+                    ?.addProcessListener(object : ProcessListener {
                         override fun processTerminated(e: ProcessEvent) {
                             syncBeforeFetch(project, project.activatedToolkit!!)
 
@@ -40,7 +40,7 @@ class UpdateCompileCommandsAction : AnAction() {
                                 true
                             )
                                 ?.addProcessListener(
-                                    object : ProcessAdapter() {
+                                    object : ProcessListener {
                                         override fun processTerminated(e: ProcessEvent) {
                                             fetchGeneratedFile(
                                                 project,
@@ -57,7 +57,7 @@ class UpdateCompileCommandsAction : AnAction() {
             } else {
                 SystemUtils.runvInConsole(project, xmakeConfiguration.updateCompileCommandsLine, false, true, true)
                     ?.addProcessListener(
-                        object : ProcessAdapter() {
+                        object : ProcessListener {
                             override fun processTerminated(e: ProcessEvent) {
                                 fetchGeneratedFile(project, project.activatedToolkit!!, "compile_commands.json")
                             }

--- a/src/main/kotlin/io/xmake/project/toolkit/ui/ToolkitComboBox.kt
+++ b/src/main/kotlin/io/xmake/project/toolkit/ui/ToolkitComboBox.kt
@@ -1,6 +1,5 @@
 package io.xmake.project.toolkit.ui
 
-import ai.grazie.utils.tryRunWithException
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.ProjectManager
@@ -91,8 +90,10 @@ class ToolkitComboBox(toolkitProperty: KMutableProperty0<Toolkit?>) : ComboBox<T
                     }
                 }
 
-                tryRunWithException<ClassCastException, Unit> {
+                try {
                     firePropertyChange("model", false, true)
+                } catch (e: ClassCastException){
+                    Log.info(e.message)
                 }
 
                 // to select configuration-level activated toolkit
@@ -123,8 +124,10 @@ class ToolkitComboBox(toolkitProperty: KMutableProperty0<Toolkit?>) : ComboBox<T
                 val toolkit = e.source as Toolkit
                 model.add(ToolkitListItem.ToolkitItem(toolkit))
                 debounce {
-                    tryRunWithException<ClassCastException, Unit> {
+                    try {
                         firePropertyChange("model", false, true)
+                    } catch (e: ClassCastException){
+                        Log.info(e.message)
                     }
                 }
             }

--- a/src/main/kotlin/io/xmake/run/XMakeRunConfiguration.kt
+++ b/src/main/kotlin/io/xmake/run/XMakeRunConfiguration.kt
@@ -3,8 +3,8 @@ package io.xmake.run
 import com.intellij.execution.Executor
 import com.intellij.execution.configuration.EnvironmentVariablesData
 import com.intellij.execution.configurations.*
-import com.intellij.execution.process.ProcessAdapter
 import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.options.SettingsEditor
@@ -137,7 +137,7 @@ class XMakeRunConfiguration(
         val xmakeConfiguration = project.xmakeConfiguration
         if (xmakeConfiguration.changed) {
             SystemUtils.runvInConsole(project, xmakeConfiguration.configurationCommandLine)
-                ?.addProcessListener(object : ProcessAdapter() {
+                ?.addProcessListener(object : ProcessListener {
                     override fun processTerminated(e: ProcessEvent) {
                         SystemUtils.runvInConsole(project, runCommandLine, false, true, true)
                     }

--- a/src/main/kotlin/io/xmake/utils/execute/CommandEx.kt
+++ b/src/main/kotlin/io/xmake/utils/execute/CommandEx.kt
@@ -8,7 +8,7 @@ import com.intellij.execution.wsl.WSLCommandLineOptions
 import com.intellij.execution.wsl.WSLDistribution
 import com.intellij.execution.wsl.WslPath
 import com.intellij.execution.wsl.rootMappings
-import com.intellij.openapi.diagnostic.fileLogger
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
@@ -25,7 +25,7 @@ import io.xmake.utils.extension.ToolkitHostExtension
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 
-private val Log = fileLogger()
+private val Log = logger<GeneralCommandLine>()
 
 private val EP_NAME: ExtensionPointName<ToolkitHostExtension> =
     ExtensionPointName("io.xmake.toolkitHostExtension")
@@ -104,7 +104,7 @@ fun runProcessWithHandler(
     val processHandler = KillableColoredProcessHandler(process, command.commandLineString, Charsets.UTF_8)
     var content = ""
 
-    processHandler.addProcessListener(object : ProcessAdapter() {
+    processHandler.addProcessListener(object : ProcessListener {
         override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {
             super.onTextAvailable(event, outputType)
             project.xmakeConsoleView.print(event.text, ConsoleViewContentType.getConsoleViewType(outputType))
@@ -119,7 +119,7 @@ fun runProcessWithHandler(
     }
 
     if (showProblem) {
-        processHandler.addProcessListener(object : ProcessAdapter() {
+        processHandler.addProcessListener(object : ProcessListener {
             override fun processTerminated(e: ProcessEvent) {
                 runBlocking(Dispatchers.Default) {
                     val problems = mutableListOf<XMakeProblem>()

--- a/src/main/kotlin/io/xmake/utils/extension/SshToolkitHostExtensionImpl.kt
+++ b/src/main/kotlin/io/xmake/utils/extension/SshToolkitHostExtensionImpl.kt
@@ -1,6 +1,5 @@
 package io.xmake.utils.extension
 
-import ai.grazie.utils.tryRunWithException
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.application.EDT
 import com.intellij.openapi.application.runWriteAction
@@ -15,7 +14,6 @@ import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.util.text.Formats
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.ssh.*
-import com.intellij.ssh.channels.SftpChannel
 import com.intellij.ssh.config.unified.SshConfig
 import com.intellij.ssh.config.unified.SshConfigManager
 import com.intellij.ssh.interaction.PlatformSshPasswordProvider
@@ -88,10 +86,12 @@ class SshToolkitHostExtensionImpl : ToolkitHostExtension {
                             SyncDirection.LOCAL_TO_UPSTREAM -> {
 
                                 Log.runCatching {
-                                    tryRunWithException<SftpChannelNoSuchFileException, List<SftpChannel.FileInfo>> {
+                                    try {
                                         sftpChannel.ls(
                                             remoteDirectory
                                         )
+                                    } catch (e: SftpChannelNoSuchFileException) {
+                                        Log.warn(e.message)
                                     }.also { Log.info("before: $it") }
                                     sftpChannel.rmRecur(remoteDirectory)
                                     Log.info("after: " + sftpChannel.ls("Project"))


### PR DESCRIPTION
**Key Points**:

- Upgraded with API Level 2025.2.
- Replaced all deprecated old implementations.
- Updated `gradle.properties` and `gradle-wrapper.properties` files.

The compatibility range has now changed to `243` - `252.*`.

This revised version has passed the `Plugin Verification`, eliminating all `Internal API` usage and `Deprecated API` usage.