### PR TITLE
Do proper splitting of command-line arguments

### DIFF
--- a/src/main/kotlin/io/xmake/run/XMakeRunConfiguration.kt
+++ b/src/main/kotlin/io/xmake/run/XMakeRunConfiguration.kt
@@ -9,6 +9,7 @@ import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
+import com.intellij.util.execution.ParametersListUtil
 import com.intellij.util.xmlb.XmlSerializer
 import com.intellij.util.xmlb.annotations.OptionTag
 import com.intellij.util.xmlb.annotations.Transient
@@ -81,13 +82,7 @@ class XMakeRunConfiguration(
                 parameters.add(runTarget)
             }
             if (runArguments != "") {
-                parameters.addAll(
-                    "\"[^\"]*\"|'[^']*'|[^\\s]+".toRegex().findAll(
-                        runArguments
-                    ).map {
-                        it.value.removeSurrounding("\"").removeSurrounding("'")
-                    }.toList()
-                )
+                parameters.addAll(ParametersListUtil.parse(runArguments))
             }
 
             // make command line

--- a/src/main/kotlin/io/xmake/run/XMakeRunConfiguration.kt
+++ b/src/main/kotlin/io/xmake/run/XMakeRunConfiguration.kt
@@ -81,9 +81,13 @@ class XMakeRunConfiguration(
                 parameters.add(runTarget)
             }
             if (runArguments != "") {
-                runArguments.split(" ").forEach {
-                    parameters.add(it)
-                }
+                parameters.addAll(
+                    "\"[^\"]*\"|'[^']*'|[^\\s]+".toRegex().findAll(
+                        runArguments
+                    ).map {
+                        it.value.removeSurrounding("\"").removeSurrounding("'")
+                    }.toList()
+                )
             }
 
             // make command line

--- a/src/main/kotlin/io/xmake/run/XMakeRunConfigurationEditor.kt
+++ b/src/main/kotlin/io/xmake/run/XMakeRunConfigurationEditor.kt
@@ -105,6 +105,7 @@ class XMakeRunConfigurationEditor(
         androidNDKDirectoryBrowser.text = configuration.androidNDKDirectory
 
         enableVerbose = configuration.enableVerbose
+        enableVerboseCheckBox.setSelected(enableVerbose)
 
         additionalConfiguration.text = configuration.additionalConfiguration
     }
@@ -134,6 +135,7 @@ class XMakeRunConfigurationEditor(
 
         configuration.androidNDKDirectory = androidNDKDirectoryBrowser.text
 
+        enableVerbose = enableVerboseCheckBox.isSelected()
         configuration.enableVerbose = enableVerbose
 
         configuration.additionalConfiguration = additionalConfiguration.text

--- a/src/main/kotlin/io/xmake/shared/XMakeConfiguration.kt
+++ b/src/main/kotlin/io/xmake/shared/XMakeConfiguration.kt
@@ -111,7 +111,13 @@ class XMakeConfiguration(val project: Project) {
                 parameters.add(configuration.buildDirectory)
             }
             if (configuration.additionalConfiguration != "") {
-                parameters.add(configuration.additionalConfiguration)
+                parameters.addAll(
+                    "\"[^\"]*\"|'[^']*'|[^\\s]+".toRegex().findAll(
+                        configuration.additionalConfiguration
+                    ).map {
+                        it.value.removeSurrounding("\"").removeSurrounding("'")
+                    }.toList()
+                )
             }
 
             // make command line

--- a/src/main/kotlin/io/xmake/shared/XMakeConfiguration.kt
+++ b/src/main/kotlin/io/xmake/shared/XMakeConfiguration.kt
@@ -6,6 +6,7 @@ import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
+import com.intellij.util.execution.ParametersListUtil
 import io.xmake.project.toolkit.activatedToolkit
 import io.xmake.run.XMakeRunConfiguration
 import io.xmake.utils.exception.XMakeRunConfigurationNotSetException
@@ -111,13 +112,7 @@ class XMakeConfiguration(val project: Project) {
                 parameters.add(configuration.buildDirectory)
             }
             if (configuration.additionalConfiguration != "") {
-                parameters.addAll(
-                    "\"[^\"]*\"|'[^']*'|[^\\s]+".toRegex().findAll(
-                        configuration.additionalConfiguration
-                    ).map {
-                        it.value.removeSurrounding("\"").removeSurrounding("'")
-                    }.toList()
-                )
+                parameters.addAll(ParametersListUtil.parse(configuration.additionalConfiguration))
             }
 
             // make command line


### PR DESCRIPTION
* Before adding new features and new modules, please go to issues to submit the relevant feature description first.
* Write good commit messages and use the same coding conventions as the rest of the project.
* Please commit code to dev branch and we will merge into master branch in feature
* Ensure your edited codes with four spaces instead of TAB.

------

* 增加新特性和新模块之前，请先到issues提交相关特性说明，经过讨论评估确认后，再进行相应的代码提交，避免做无用工作。
* 编写友好可读的提交信息，并使用与工程代码相同的代码规范，代码请用4个空格字符代替tab缩进。
* 请提交代码到dev分支，如果通过，我们会在特定时间合并到master分支上。
* 为了规范化提交日志的格式，commit消息，不要用中文，请用英文描述。

------

Currently, if you try to add several arguments in the "Program Argument" or "Additional Configurations" field, the plugin just passes the entire field as a single argument to the program/`xmake config`, resulting in a situation where there is no way to pass several arguments:

<img width="3280" height="478" alt="CleanShot 2025-10-16 at 18 48 23@2x" src="https://github.com/user-attachments/assets/d51461c4-af0e-4349-a535-294642afe3c7" />

This PR tries to make this field behave similarly to what the built-in CMake "Program Arguments" do, i.e., treat single/double quoted whitespace as non-splitting tokens, and then strip said quotes. See the table below for details.

| "Program Argument" field | Actual invocation of program | # of arguments |
|--------------------------------------------------------|------------------------------------------------|----------------|
| a b                                                    | `program a b`                                  | 2              |
| a b "c d" 'e f'                                        | `program a b "c d" 'e f'`                      | 4              |
| --cc=A --cxx B EE'F' GG"H"D "--A B"                           | `program --cc=A --cxx B EE'F' GGHD "--A B"`       | 6              |

Also fixes a minor issue: the "Enable verbose output" checkbox currently doesn't really work; you can check it, click ok, but the next time you edit the config, the checkbox is still unselected, and -v is not added to the parameter. After this PR, it works properly.