### PR TITLE
Remove usage of deprecated APIs

### DIFF
--- a/src/main/kotlin/io/xmake/project/toolkit/ToolkitHost.kt
+++ b/src/main/kotlin/io/xmake/project/toolkit/ToolkitHost.kt
@@ -4,7 +4,7 @@ import com.intellij.execution.wsl.WSLDistribution
 import com.intellij.execution.wsl.WslDistributionManager
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.SystemInfo
+import com.intellij.util.system.OS
 import com.intellij.util.xmlb.annotations.Attribute
 import com.intellij.util.xmlb.annotations.Tag
 import io.xmake.project.toolkit.ToolkitHostType.*
@@ -23,7 +23,7 @@ data class ToolkitHost(
     constructor(type: ToolkitHostType, target: Any? = null) : this(type) {
         this.target = target
         this.id = when (type) {
-            LOCAL -> SystemInfo.getOsName()
+            LOCAL -> OS.CURRENT.name
             WSL -> (target as WSLDistribution).id
             SSH -> EP_NAME.extensions.first { it.KEY == "SSH" }.getTargetId(target)
         }

--- a/src/main/kotlin/io/xmake/project/toolkit/ToolkitManager.kt
+++ b/src/main/kotlin/io/xmake/project/toolkit/ToolkitManager.kt
@@ -10,7 +10,7 @@ import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
-import com.intellij.openapi.util.SystemInfo
+import com.intellij.util.system.OS
 import com.intellij.util.xmlb.annotations.XCollection
 import io.xmake.project.toolkit.ToolkitHostType.*
 import io.xmake.run.XMakeRunConfiguration
@@ -74,7 +74,7 @@ class ToolkitManager(private val scope: CoroutineScope) : PersistentStateCompone
     private fun detectToolkitLocation(host: ToolkitHost): Flow<String> = flow {
         val process = probeXmakeLocCommand.let {
             when (host.type) {
-                LOCAL -> (if (SystemInfo.isWindows) probeXmakeLocCommandOnWin else it).createLocalProcess()
+                LOCAL -> (if (OS.CURRENT == OS.Windows) probeXmakeLocCommandOnWin else it).createLocalProcess()
                 WSL -> it.createWslProcess(host.target as WSLDistribution)
                 SSH -> with(EP_NAME.extensions.first { it.KEY == "SSH" }) { it.createProcess(host) }
             }
@@ -126,7 +126,7 @@ class ToolkitManager(private val scope: CoroutineScope) : PersistentStateCompone
                 }.flowOn(Dispatchers.IO).buffer().filterNot { it.isBlank() }.map { versionString ->
                     when (host.type) {
                         LOCAL -> {
-                            val name = SystemInfo.getOsName()
+                            val name = OS.CURRENT.name
                             Toolkit(name, host, path, versionString)
                         }
 


### PR DESCRIPTION
Remove usage of deprecated APIs in CLion 2025.3, as shown in the `verifyPlugin` report:

```
Plugin io.xmake:1.4.7 against CL-253.28294.335: Compatible. 2 usages of scheduled for removal API. 17 usages of experimental API
Deprecated API usages (2): 
    #Deprecated method com.intellij.openapi.util.SystemInfo.getOsName() invocation
        Deprecated method com.intellij.openapi.util.SystemInfo.getOsName() : java.lang.String is invoked in io.xmake.project.toolkit.ToolkitManager.detectXMakeToolkits$1.versionFlow$1.invokeSuspend$.inlined.map$1$2.emit(Object, Continuation) : Object. This method will be removed in a future release
        Deprecated method com.intellij.openapi.util.SystemInfo.getOsName() : java.lang.String is invoked in io.xmake.project.toolkit.ToolkitHost.<init>(ToolkitHostType, Object). This method will be removed in a future release
```