### PR TITLE
Improve GDB Dap support

### DIFF
--- a/change-notes.html
+++ b/change-notes.html
@@ -1,3 +1,8 @@
+<strong>1.4.17</strong>
+<ul>
+    <li>[FIX]: Fail fast with a clear notification when selected gdb does not support DAP (need GDB 14.1+)</li>
+    <li>[IMPROVE]: Enhance Windows DAP driver diagnostics logging (version/exit/output)</li>
+</ul>
 <strong>1.4.16</strong>
 <ul>
     <li>[FIX]: Fix build mode parsing compatibility for modes without "mode." prefix</li>

--- a/clion-debug/src/main/kotlin/io/xmake/debug/clion/DefaultDebugConfigurations.kt
+++ b/clion-debug/src/main/kotlin/io/xmake/debug/clion/DefaultDebugConfigurations.kt
@@ -148,7 +148,9 @@ object DefaultDebugConfigurations {
                 "stopOnEntry" to false,
                 "cwd" to "\${workspaceFolder}",
                 "args" to emptyList<String>(),
-                "environment" to emptyMap<String, String>()
+                "environment" to emptyMap<String, String>(),
+                "sourceMap" to emptyMap<String, Any>(),
+                "showDisassembly" to "auto"
             )
             else -> defaultDapConfig
         }

--- a/clion-debug/src/main/kotlin/io/xmake/debug/clion/XMakeDapDriverConfiguration.kt
+++ b/clion-debug/src/main/kotlin/io/xmake/debug/clion/XMakeDapDriverConfiguration.kt
@@ -112,6 +112,21 @@ class XMakeDapDriverConfiguration(
                 return
             }
 
+            val output = runCatching { process.inputStream.bufferedReader().readText() }.getOrDefault("")
+            val firstLine = output.lineSequence().firstOrNull()?.trim().orEmpty()
+            Logger.i(
+                "XMakeDapDriverConfiguration",
+                "diag: $driverName driver=${File(driverPath).name} exit=${process.exitValue()} version=${if (firstLine.isBlank()) "<empty>" else firstLine}"
+            )
+
+            if (process.exitValue() != 0) {
+                val trimmed = output.trim()
+                if (trimmed.isNotBlank()) {
+                    val truncated = if (trimmed.length <= 600) trimmed else trimmed.take(600) + "…"
+                    Logger.w("XMakeDapDriverConfiguration", "diag: output: $truncated")
+                }
+            }
+
             if (process.exitValue() == -1073741515 && !missingDllNotified) {
                 missingDllNotified = true
                 notifyDriverMissingDllHint()

--- a/clion-debug/src/main/kotlin/io/xmake/debug/clion/XMakeDapDriverConfiguration.kt
+++ b/clion-debug/src/main/kotlin/io/xmake/debug/clion/XMakeDapDriverConfiguration.kt
@@ -54,7 +54,7 @@ class XMakeDapDriverConfiguration(
         val commandLine = GeneralCommandLine(driverPath)
             .withWorkDirectory(project.basePath)
             .withEnvironment(EnvironmentUtil.getEnvironmentMap())
-        
+
         // Add -i dap flag for GDB driver
         if (driverName == "gdb-dap") {
             commandLine.addParameter("-i")
@@ -116,8 +116,9 @@ class XMakeDapDriverConfiguration(
             )
             
             // Merge with existing sourceMap from user config
-            val existingSourceMap = config["sourceMap"] as? Map<*, *>
-            val mergedSourceMap = mutableMapOf<Any?, Any?>()
+            @Suppress("UNCHECKED_CAST")
+            val existingSourceMap = config["sourceMap"] as? Map<String, Any>
+            val mergedSourceMap = mutableMapOf<String, Any>()
             
             if (existingSourceMap != null) {
                 mergedSourceMap.putAll(existingSourceMap)
@@ -134,8 +135,6 @@ class XMakeDapDriverConfiguration(
             config["sourceMap"] = mergedSourceMap
             config["sourceFileMap"] = mergedSourceMap
         }
-        
-        Logger.d(TAG, "Applied GDB DAP configuration: stopOnEntry=true")
     }
     
     /**

--- a/clion-debug/src/main/kotlin/io/xmake/debug/clion/XMakeDapDriverConfiguration.kt
+++ b/clion-debug/src/main/kotlin/io/xmake/debug/clion/XMakeDapDriverConfiguration.kt
@@ -51,9 +51,17 @@ class XMakeDapDriverConfiguration(
     }
 
     override fun createDriverCommandLine(@NotNull driver: DebuggerDriver, @NotNull arch: ArchitectureType): GeneralCommandLine {
-        return GeneralCommandLine(driverPath)
+        val commandLine = GeneralCommandLine(driverPath)
             .withWorkDirectory(project.basePath)
             .withEnvironment(EnvironmentUtil.getEnvironmentMap())
+        
+        // Add -i dap flag for GDB driver
+        if (driverName == "gdb-dap") {
+            commandLine.addParameter("-i")
+            commandLine.addParameter("dap")
+        }
+        
+        return commandLine
     }
 
     override fun getDapLaunchOptions(commandLine: GeneralCommandLine): Map<String, Any> {

--- a/clion-debug/src/main/kotlin/io/xmake/debug/clion/XMakeDapDriverConfiguration.kt
+++ b/clion-debug/src/main/kotlin/io/xmake/debug/clion/XMakeDapDriverConfiguration.kt
@@ -75,18 +75,78 @@ class XMakeDapDriverConfiguration(
         val userConfigJson = userLaunchConfig
         val mergedConfig = DefaultDebugConfigurations.parseLaunchConfig(userConfigJson)
         
-        // Build final configuration
+        // Merge configurations
         val finalConfig = mutableMapOf<String, Any>()
         finalConfig.putAll(defaultConfig)
         finalConfig.putAll(mergedConfig)
         
-        // Override with runtime values
+        // Set target program information
         finalConfig["program"] = commandLine.exePath
         finalConfig["cwd"] = commandLine.workDirectory?.path ?: project.basePath ?: ""
         finalConfig["env"] = commandLine.environment
         finalConfig["args"] = commandLine.parametersList.list
         
+        // Apply driver-specific configurations
+        applyDriverSpecificConfigurations(finalConfig)
+        
         return finalConfig
+    }
+    
+    /**
+     * Apply driver-specific configurations to enhance debugging experience
+     */
+    private fun applyDriverSpecificConfigurations(config: MutableMap<String, Any>) {
+        when (driverName) {
+            "gdb-dap" -> applyGdbDapConfigurations(config)
+            "lldb-dap" -> applyLldbDapConfigurations(config)
+        }
+    }
+    
+    /**
+     * Apply GDB DAP specific configurations
+     */
+    private fun applyGdbDapConfigurations(config: MutableMap<String, Any>) {
+        // Force stopOnEntry for GDB to ensure breakpoints work reliably
+        config["stopOnEntry"] = true
+
+        // GDB-specific source path mapping
+        // This is necessary because GDB often returns relative paths or absolute paths that differ from IDE's view
+        val basePath = project.basePath ?: ""
+        if (basePath.isNotEmpty()) {
+            val autoSourceMap = mapOf(
+                basePath to ".",
+                "$basePath/src" to "src"
+            )
+            
+            // Merge with existing sourceMap from user config
+            val existingSourceMap = config["sourceMap"] as? Map<*, *>
+            val mergedSourceMap = mutableMapOf<Any?, Any?>()
+            
+            if (existingSourceMap != null) {
+                mergedSourceMap.putAll(existingSourceMap)
+            }
+            
+            // Apply auto mappings only if not already present
+            autoSourceMap.forEach { (k, v) ->
+                if (!mergedSourceMap.containsKey(k)) {
+                    mergedSourceMap[k] = v
+                }
+            }
+            
+            // Use both keys for compatibility: sourceMap (common), sourceFileMap (GDB specific)
+            config["sourceMap"] = mergedSourceMap
+            config["sourceFileMap"] = mergedSourceMap
+        }
+        
+        Logger.d(TAG, "Applied GDB DAP configuration: stopOnEntry=true")
+    }
+    
+    /**
+     * Apply LLDB DAP specific configurations (placeholder for future enhancements)
+     */
+    private fun applyLldbDapConfigurations(config: MutableMap<String, Any>) {
+        // LLDB-specific configurations can be added here if needed
+        // Currently using defaults from DefaultDebugConfigurations
     }
 
     override fun getDapAttachOptions(pid: Int): Map<String, Any> {

--- a/clion-debug/src/main/kotlin/io/xmake/debug/clion/XMakeDapDriverConfiguration.kt
+++ b/clion-debug/src/main/kotlin/io/xmake/debug/clion/XMakeDapDriverConfiguration.kt
@@ -106,9 +106,6 @@ class XMakeDapDriverConfiguration(
      * Apply GDB DAP specific configurations
      */
     private fun applyGdbDapConfigurations(config: MutableMap<String, Any>) {
-        // Force stopOnEntry for GDB to ensure breakpoints work reliably
-        config["stopOnEntry"] = true
-
         // GDB-specific source path mapping
         // This is necessary because GDB often returns relative paths or absolute paths that differ from IDE's view
         val basePath = project.basePath ?: ""

--- a/clion-debug/src/main/kotlin/io/xmake/debug/clion/XMakeDapDriverConfiguration.kt
+++ b/clion-debug/src/main/kotlin/io/xmake/debug/clion/XMakeDapDriverConfiguration.kt
@@ -20,7 +20,6 @@
  */
 package io.xmake.debug.clion
 
-import io.xmake.debug.clion.utils.Logger
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.openapi.project.Project
 import com.intellij.util.EnvironmentUtil
@@ -46,10 +45,6 @@ class XMakeDapDriverConfiguration(
     private val env: Map<String, String> = emptyMap()
 ) : DapDriverConfiguration(project, driverName, false, false) {
     
-    companion object {
-        private const val TAG = "XMakeDapDriverConfig"
-    }
-
     override fun createDriverCommandLine(@NotNull driver: DebuggerDriver, @NotNull arch: ArchitectureType): GeneralCommandLine {
         val commandLine = GeneralCommandLine(driverPath)
             .withWorkDirectory(project.basePath)

--- a/clion-debug/src/main/kotlin/io/xmake/debug/clion/XMakeDapDriverConfiguration.kt
+++ b/clion-debug/src/main/kotlin/io/xmake/debug/clion/XMakeDapDriverConfiguration.kt
@@ -21,16 +21,20 @@
 package io.xmake.debug.clion
 
 import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationType
+import com.intellij.notification.Notifications
 import com.intellij.openapi.project.Project
 import com.intellij.util.EnvironmentUtil
-import com.intellij.openapi.util.text.StringUtil
+import com.intellij.openapi.util.SystemInfo
 import com.jetbrains.cidr.ArchitectureType
 import com.jetbrains.cidr.execution.debugger.backend.DebuggerDriver
 import com.jetbrains.cidr.execution.debugger.backend.dap.DapDriver
 import com.jetbrains.cidr.execution.debugger.backend.dap.DapDriverConfiguration
+import io.xmake.debug.clion.utils.Logger
 import org.jetbrains.annotations.NotNull
 import java.io.File
-import java.util.*
+import java.util.concurrent.TimeUnit
 
 /**
  * XMake DAP driver configuration for CLion debugging
@@ -44,19 +48,87 @@ class XMakeDapDriverConfiguration(
     private val args: List<String> = emptyList(),
     private val env: Map<String, String> = emptyMap()
 ) : DapDriverConfiguration(project, driverName, false, false) {
-    
+
+    private var missingDllNotified = false
+    private var driverDiagnosticChecked = false
+
     override fun createDriverCommandLine(@NotNull driver: DebuggerDriver, @NotNull arch: ArchitectureType): GeneralCommandLine {
+        val env = EnvironmentUtil.getEnvironmentMap().toMutableMap()
+        if (this.env.isNotEmpty()) {
+            env.putAll(this.env)
+        }
+
+        val driverDir = File(driverPath).parent
+
+        if (driverDir != null) {
+            val pathKey = env.keys.find { it.equals("path", ignoreCase = true) }
+                ?: if (SystemInfo.isWindows) "Path" else "PATH"
+
+            val currentPath = env[pathKey] ?: ""
+
+            val newPath = if (currentPath.isBlank()) driverDir else "$driverDir${File.pathSeparator}$currentPath"
+            env[pathKey] = newPath
+        }
+
+        if (SystemInfo.isWindows) {
+            if (!driverDiagnosticChecked) {
+                driverDiagnosticChecked = true
+                tryRunDriverDiagnostic(driverDir, env)
+            }
+        }
+
         val commandLine = GeneralCommandLine(driverPath)
             .withWorkDirectory(project.basePath)
-            .withEnvironment(EnvironmentUtil.getEnvironmentMap())
+            .withEnvironment(env)
 
         // Add -i dap flag for GDB driver
         if (driverName == "gdb-dap") {
             commandLine.addParameter("-i")
             commandLine.addParameter("dap")
         }
-        
+
         return commandLine
+    }
+
+    private fun tryRunDriverDiagnostic(driverDir: String?, env: Map<String, String>) {
+        val args = listOf("--version")
+
+        try {
+            val pb = ProcessBuilder(listOf(driverPath) + args)
+            if (driverDir != null) {
+                pb.directory(File(driverDir))
+            }
+            pb.redirectErrorStream(true)
+
+            val pbEnv = pb.environment()
+            pbEnv.clear()
+            pbEnv.putAll(env)
+
+            val process = pb.start()
+            val finished = process.waitFor(1500, TimeUnit.MILLISECONDS)
+            if (!finished) {
+                process.destroy()
+                Logger.w("XMakeDapDriverConfiguration", "diag: timeout running $driverPath ${args.joinToString(" ")}")
+                return
+            }
+
+            if (process.exitValue() == -1073741515 && !missingDllNotified) {
+                missingDllNotified = true
+                notifyDriverMissingDllHint()
+            }
+        } catch (t: Throwable) {
+            Logger.w("XMakeDapDriverConfiguration", "diag: failed to run driver $driverPath: ${t.message}")
+        }
+    }
+
+    private fun notifyDriverMissingDllHint() {
+        val message = "Failed to start the DAP driver (0xC0000135). This is likely caused by missing DLL dependencies.<br/><br/>" +
+            "Please run the driver manually in a terminal (e.g. ${File(driverPath).name} --version) and install/copy the missing DLLs based on the error output.<br/><br/>" +
+            "driver=$driverPath"
+        Notifications.Bus.notify(
+            Notification("XMake Debug", "DAP driver may be missing DLLs", message, NotificationType.ERROR),
+            project
+        )
     }
 
     override fun getDapLaunchOptions(commandLine: GeneralCommandLine): Map<String, Any> {
@@ -65,28 +137,28 @@ class XMakeDapDriverConfiguration(
             "gdb-dap" -> DefaultDebugConfigurations.getDefaultConfigForDriver("gdb-dap")
             else -> DefaultDebugConfigurations.getDefaultConfigForDriver("lldb-dap")
         }
-        
+
         // Get user configuration from run configuration
         val userConfigJson = userLaunchConfig
         val mergedConfig = DefaultDebugConfigurations.parseLaunchConfig(userConfigJson)
-        
+
         // Merge configurations
         val finalConfig = mutableMapOf<String, Any>()
         finalConfig.putAll(defaultConfig)
         finalConfig.putAll(mergedConfig)
-        
+
         // Set target program information
         finalConfig["program"] = commandLine.exePath
         finalConfig["cwd"] = commandLine.workDirectory?.path ?: project.basePath ?: ""
         finalConfig["env"] = commandLine.environment
         finalConfig["args"] = commandLine.parametersList.list
-        
+
         // Apply driver-specific configurations
         applyDriverSpecificConfigurations(finalConfig)
-        
+
         return finalConfig
     }
-    
+
     /**
      * Apply driver-specific configurations to enhance debugging experience
      */
@@ -96,7 +168,7 @@ class XMakeDapDriverConfiguration(
             "lldb-dap" -> applyLldbDapConfigurations(config)
         }
     }
-    
+
     /**
      * Apply GDB DAP specific configurations
      */
@@ -109,29 +181,29 @@ class XMakeDapDriverConfiguration(
                 basePath to ".",
                 "$basePath/src" to "src"
             )
-            
+
             // Merge with existing sourceMap from user config
             @Suppress("UNCHECKED_CAST")
             val existingSourceMap = config["sourceMap"] as? Map<String, Any>
             val mergedSourceMap = mutableMapOf<String, Any>()
-            
+
             if (existingSourceMap != null) {
                 mergedSourceMap.putAll(existingSourceMap)
             }
-            
+
             // Apply auto mappings only if not already present
             autoSourceMap.forEach { (k, v) ->
                 if (!mergedSourceMap.containsKey(k)) {
                     mergedSourceMap[k] = v
                 }
             }
-            
+
             // Use both keys for compatibility: sourceMap (common), sourceFileMap (GDB specific)
             config["sourceMap"] = mergedSourceMap
             config["sourceFileMap"] = mergedSourceMap
         }
     }
-    
+
     /**
      * Apply LLDB DAP specific configurations (placeholder for future enhancements)
      */

--- a/clion-debug/src/main/kotlin/io/xmake/debug/clion/utils/Logger.kt
+++ b/clion-debug/src/main/kotlin/io/xmake/debug/clion/utils/Logger.kt
@@ -27,91 +27,91 @@ import java.time.format.DateTimeFormatter
  * Simple logger implementation for CLion debug module
  */
 object Logger {
-    
+
     private const val DEFAULT_TAG = "ClionDebugModule"
-    
+
     // Log levels
     enum class LogLevel {
         DEBUG,
-        VERBOSE, 
+        VERBOSE,
         INFO,
         WARN,
         ERROR
     }
-    
+
     // Current log level (can be configured)
     private var currentLogLevel = LogLevel.DEBUG
-    
+
     /**
      * Set the current log level
      */
     fun setLogLevel(level: LogLevel) {
         currentLogLevel = level
     }
-    
+
     /**
      * Debug level log with default tag
      */
     fun d(message: String) {
         d(DEFAULT_TAG, message)
     }
-    
+
     /**
      * Debug level log with tag
      */
     fun d(tag: String, message: String) {
         log(LogLevel.DEBUG, tag, message)
     }
-    
+
     /**
      * Verbose level log with default tag
      */
     fun v(message: String) {
         v(DEFAULT_TAG, message)
     }
-    
+
     /**
      * Verbose level log with tag
      */
     fun v(tag: String, message: String) {
         log(LogLevel.VERBOSE, tag, message)
     }
-    
+
     /**
      * Info level log with default tag
      */
     fun i(message: String) {
         i(DEFAULT_TAG, message)
     }
-    
+
     /**
      * Info level log with tag
      */
     fun i(tag: String, message: String) {
         log(LogLevel.INFO, tag, message)
     }
-    
+
     /**
      * Warning level log with default tag
      */
     fun w(message: String) {
         w(DEFAULT_TAG, message)
     }
-    
+
     /**
      * Warning level log with tag
      */
     fun w(tag: String, message: String) {
         log(LogLevel.WARN, tag, message)
     }
-    
+
     /**
      * Warning level log with exception and default tag
      */
     fun w(message: String, throwable: Throwable) {
         w(DEFAULT_TAG, message, throwable)
     }
-    
+
     /**
      * Warning level log with exception and tag
      */
@@ -119,28 +119,28 @@ object Logger {
         log(LogLevel.WARN, tag, message)
         throwable.printStackTrace()
     }
-    
+
     /**
      * Error level log with default tag
      */
     fun e(message: String) {
         e(DEFAULT_TAG, message)
     }
-    
+
     /**
      * Error level log with tag
      */
     fun e(tag: String, message: String) {
         log(LogLevel.ERROR, tag, message)
     }
-    
+
     /**
      * Error level log with exception and default tag
      */
     fun e(message: String, throwable: Throwable) {
         e(DEFAULT_TAG, message, throwable)
     }
-    
+
     /**
      * Error level log with exception and tag
      */
@@ -148,7 +148,7 @@ object Logger {
         log(LogLevel.ERROR, tag, message)
         throwable.printStackTrace()
     }
-    
+
     /**
      * Core logging method
      */
@@ -156,12 +156,12 @@ object Logger {
         if (level.ordinal < currentLogLevel.ordinal) {
             return
         }
-        
+
         // Use println for all logging in the debug module
         val timestamp = LocalDateTime.now().format(
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
         )
-        
+
         val levelChar = when (level) {
             LogLevel.DEBUG -> "D"
             LogLevel.VERBOSE -> "V"
@@ -169,7 +169,7 @@ object Logger {
             LogLevel.WARN -> "W"
             LogLevel.ERROR -> "E"
         }
-        
+
         println("[$timestamp] $levelChar/$tag: $message")
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=1.4.16
+pluginVersion=1.4.17
 pluginSinceBuild=243
 
 runIdeVersion=2025.3

--- a/src/main/kotlin/io/xmake/debug/DapDriverDetector.kt
+++ b/src/main/kotlin/io/xmake/debug/DapDriverDetector.kt
@@ -55,15 +55,14 @@ object DapDriverDetector {
         val fileName = file.name.lowercase()
         return when {
             fileName.contains("lldb-dap") -> DapDriverType.LLDB_DAP
+            fileName.contains("lldb-vscode") -> DapDriverType.LLDB_DAP
             fileName.contains("gdb") && !fileName.contains("lldb") -> DapDriverType.GDB_DAP
-            fileName.contains("lldb") -> DapDriverType.LLDB_DAP
             else -> {
-                // Try to detect by checking file content or help output
                 try {
                     val process = ProcessBuilder(path, "--version").start()
                     val output = process.inputStream.bufferedReader().readText().lowercase()
                     when {
-                        output.contains("lldb") -> DapDriverType.LLDB_DAP
+                        output.contains("lldb-dap") || output.contains("lldb-vscode") -> DapDriverType.LLDB_DAP
                         output.contains("gdb") -> DapDriverType.GDB_DAP
                         else -> DapDriverType.UNKNOWN
                     }

--- a/src/main/kotlin/io/xmake/debug/DapDriverDetector.kt
+++ b/src/main/kotlin/io/xmake/debug/DapDriverDetector.kt
@@ -23,6 +23,7 @@ package io.xmake.debug
 import com.intellij.openapi.util.SystemInfo
 import io.xmake.utils.Logger
 import java.io.File
+import java.util.concurrent.TimeUnit
 
 /**
  * DAP driver path detection utility
@@ -34,13 +35,108 @@ object DapDriverDetector {
     data class DapDriverInfo(
         val path: String,
         val type: DapDriverType,
-        val displayName: String
+        val displayName: String,
+        val dapCapable: Boolean = true,
+        val diagnostics: String? = null
     )
     
     enum class DapDriverType(val displayName: String) {
         LLDB_DAP("LLDB DAP"),
         GDB_DAP("GDB DAP"),
         UNKNOWN("Unknown DAP")
+    }
+
+    private data class ProcessResult(
+        val exitCode: Int?,
+        val output: String,
+        val timedOut: Boolean
+    )
+
+    private data class GdbDapCapability(
+        val dapCapable: Boolean,
+        val versionText: String?,
+        val diagnostics: String?
+    )
+
+    private val gdbCapabilityCache: MutableMap<String, GdbDapCapability> = mutableMapOf()
+
+    private fun runProcess(
+        executable: String,
+        args: List<String>,
+        timeoutMillis: Long
+    ): ProcessResult {
+        return try {
+            val pb = ProcessBuilder(listOf(executable) + args)
+            pb.redirectErrorStream(true)
+            val process = pb.start()
+            val finished = process.waitFor(timeoutMillis, TimeUnit.MILLISECONDS)
+            if (!finished) {
+                process.destroy()
+                return ProcessResult(exitCode = null, output = "", timedOut = true)
+            }
+            val output = process.inputStream.bufferedReader().readText()
+            ProcessResult(exitCode = process.exitValue(), output = output, timedOut = false)
+        } catch (e: Throwable) {
+            ProcessResult(exitCode = null, output = e.message ?: "", timedOut = false)
+        }
+    }
+
+    private fun parseGdbVersion(output: String): Pair<Int, Int>? {
+        val firstLine = output.lineSequence().firstOrNull()?.trim().orEmpty()
+        if (firstLine.isBlank()) return null
+        val match = Regex("""\b(\d+)\.(\d+)(?:\.\d+)?\b""").find(firstLine) ?: return null
+        val major = match.groupValues.getOrNull(1)?.toIntOrNull() ?: return null
+        val minor = match.groupValues.getOrNull(2)?.toIntOrNull() ?: return null
+        return major to minor
+    }
+
+    private fun truncateDiagnostics(text: String, maxChars: Int = 600): String {
+        val trimmed = text.trim()
+        if (trimmed.length <= maxChars) return trimmed
+        return trimmed.take(maxChars) + "…"
+    }
+
+    @Synchronized
+    private fun getGdbDapCapability(path: String): GdbDapCapability {
+        gdbCapabilityCache[path]?.let { return it }
+
+        val versionResult = runProcess(path, listOf("--version"), 1500)
+        val versionText = versionResult.output.lineSequence().firstOrNull()?.trim()
+        val parsed = parseGdbVersion(versionResult.output)
+        if (parsed != null) {
+            val (major, minor) = parsed
+            val dapCapable = major > 14 || (major == 14 && minor >= 1)
+            val capability = if (dapCapable) {
+                GdbDapCapability(true, versionText, null)
+            } else {
+                GdbDapCapability(
+                    false,
+                    versionText,
+                    "GDB ${major}.${minor} detected; DAP requires GDB 14.1+."
+                )
+            }
+            gdbCapabilityCache[path] = capability
+            return capability
+        }
+
+        val dapProbe = runProcess(path, listOf("-i", "dap", "--version"), 1500)
+        val probeOutput = truncateDiagnostics(dapProbe.output)
+        val probeDiagnostics = if (dapProbe.timedOut) {
+            "Timed out probing DAP interpreter via: $path -i dap --version"
+        } else if (dapProbe.exitCode != null && dapProbe.exitCode != 0) {
+            if (probeOutput.isBlank()) {
+                "Failed probing DAP interpreter via: $path -i dap --version (exit=${dapProbe.exitCode})"
+            } else {
+                "Failed probing DAP interpreter (exit=${dapProbe.exitCode}): $probeOutput"
+            }
+        } else {
+            null
+        }
+        val dapCapable = probeDiagnostics == null
+
+        val capability = GdbDapCapability(dapCapable, versionText, probeDiagnostics)
+        gdbCapabilityCache[path] = capability
+        return capability
     }
     
     /**
@@ -59,8 +155,8 @@ object DapDriverDetector {
             fileName.contains("gdb") && !fileName.contains("lldb") -> DapDriverType.GDB_DAP
             else -> {
                 try {
-                    val process = ProcessBuilder(path, "--version").start()
-                    val output = process.inputStream.bufferedReader().readText().lowercase()
+                    val result = runProcess(path, listOf("--version"), 1500)
+                    val output = result.output.lowercase()
                     when {
                         output.contains("lldb-dap") || output.contains("lldb-vscode") -> DapDriverType.LLDB_DAP
                         output.contains("gdb") -> DapDriverType.GDB_DAP
@@ -128,7 +224,25 @@ object DapDriverDetector {
             if (file.exists() && file.canExecute()) {
                 val type = detectDriverType(path)
                 if (type != DapDriverType.UNKNOWN) {
-                    drivers.add(DapDriverInfo(path, type, type.displayName))
+                    if (type == DapDriverType.GDB_DAP) {
+                        val capability = getGdbDapCapability(path)
+                        val displayName = if (capability.dapCapable) {
+                            type.displayName
+                        } else {
+                            "${type.displayName} (need 14.1+)"
+                        }
+                        drivers.add(
+                            DapDriverInfo(
+                                path = path,
+                                type = type,
+                                displayName = displayName,
+                                dapCapable = capability.dapCapable,
+                                diagnostics = capability.diagnostics ?: capability.versionText
+                            )
+                        )
+                    } else {
+                        drivers.add(DapDriverInfo(path, type, type.displayName, dapCapable = true))
+                    }
                 }
             }
         }
@@ -144,8 +258,8 @@ object DapDriverDetector {
         
         // Prefer LLDB over GDB
         return drivers.find { it.type == DapDriverType.LLDB_DAP }
-            ?: drivers.find { it.type == DapDriverType.GDB_DAP }
-            ?: drivers.firstOrNull()
+            ?: drivers.find { it.type == DapDriverType.GDB_DAP && it.dapCapable }
+            ?: drivers.find { it.dapCapable }
     }
     
     /**
@@ -159,7 +273,23 @@ object DapDriverDetector {
         
         val type = detectDriverType(path)
         return if (type != DapDriverType.UNKNOWN) {
-            DapDriverInfo(path, type, type.displayName)
+            if (type == DapDriverType.GDB_DAP) {
+                val capability = getGdbDapCapability(path)
+                val displayName = if (capability.dapCapable) {
+                    type.displayName
+                } else {
+                    "${type.displayName} (need 14.1+)"
+                }
+                DapDriverInfo(
+                    path = path,
+                    type = type,
+                    displayName = displayName,
+                    dapCapable = capability.dapCapable,
+                    diagnostics = capability.diagnostics ?: capability.versionText
+                )
+            } else {
+                DapDriverInfo(path, type, type.displayName, dapCapable = true)
+            }
         } else {
             null
         }

--- a/src/main/kotlin/io/xmake/debug/DapDriverDetector.kt
+++ b/src/main/kotlin/io/xmake/debug/DapDriverDetector.kt
@@ -55,9 +55,8 @@ object DapDriverDetector {
         val fileName = file.name.lowercase()
         return when {
             fileName.contains("lldb-dap") -> DapDriverType.LLDB_DAP
-            fileName.contains("gdb-dap") -> DapDriverType.GDB_DAP
+            fileName.contains("gdb") && !fileName.contains("lldb") -> DapDriverType.GDB_DAP
             fileName.contains("lldb") -> DapDriverType.LLDB_DAP
-            fileName.contains("gdb") -> DapDriverType.GDB_DAP
             else -> {
                 // Try to detect by checking file content or help output
                 try {
@@ -90,19 +89,19 @@ object DapDriverDetector {
                 "/opt/homebrew/opt/llvm/bin/lldb-dap",
                 "/usr/bin/lldb-dap",
                 "/usr/local/bin/lldb-dap",
-                "/usr/local/opt/llvm/bin/gdb-dap",
-                "/opt/homebrew/opt/llvm/bin/gdb-dap",
-                "/usr/bin/gdb-dap",
-                "/usr/local/bin/gdb-dap"
+                "/usr/local/opt/llvm/bin/gdb",
+                "/opt/homebrew/opt/llvm/bin/gdb",
+                "/usr/bin/gdb",
+                "/usr/local/bin/gdb"
             ))
         } else if (SystemInfo.isLinux) {
             // Linux paths
             paths.addAll(listOf(
                 "/usr/bin/lldb-dap",
                 "/usr/local/bin/lldb-dap",
-                "/usr/bin/gdb-dap",
-                "/usr/local/bin/gdb-dap",
-                "/snap/bin/lldb-dap",
+                "/usr/bin/gdb",
+                "/usr/local/bin/gdb",
+                "/snap/bin/gdb",
                 "/snap/bin/gdb-dap"
             ))
         } else if (SystemInfo.isWindows) {
@@ -111,8 +110,8 @@ object DapDriverDetector {
                 "C:\\Program Files\\LLVM\\bin\\lldb-dap.exe",
                 "C:\\Program Files (x86)\\LLVM\\bin\\lldb-dap.exe",
                 "C:\\msys64\\mingw64\\bin\\lldb-dap.exe",
-                "C:\\msys64\\mingw64\\bin\\gdb-dap.exe",
-                "C:\\Program Files\\GDB\\bin\\gdb-dap.exe"
+                "C:\\msys64\\mingw64\\bin\\gdb.exe",
+                "C:\\Program Files\\GDB\\bin\\gdb.exe"
             ))
         }
         

--- a/src/main/kotlin/io/xmake/debug/XMakeDebugSession.kt
+++ b/src/main/kotlin/io/xmake/debug/XMakeDebugSession.kt
@@ -189,9 +189,28 @@ class XMakeDebugSession(private val state: RunProfileState, private val environm
                 
                 // Get driver name from DapDriverDetector
                 val driverInfo = io.xmake.debug.DapDriverDetector.validateDriverPath(dapDriverPath)
-                val driverName = when (driverInfo?.type) {
+                if (driverInfo == null) {
+                    throw Exception("Invalid DAP driver path: $dapDriverPath")
+                }
+
+                val driverName = when (driverInfo.type) {
                     io.xmake.debug.DapDriverDetector.DapDriverType.GDB_DAP -> "gdb-dap"
                     else -> "lldb-dap"
+                }
+
+                if (driverName == "gdb-dap" && !driverInfo.dapCapable) {
+                    val detail = driverInfo.diagnostics?.let { "<br/><br/>$it" } ?: ""
+                    NotificationGroupManager.getInstance()
+                        .getNotificationGroup("XMake.NotificationGroup")
+                        .createNotification(
+                            "GDB does not support DAP",
+                            "The selected GDB does not support Debug Adapter Protocol (DAP).<br/>" +
+                                "Please install GDB 14.1+ (or use lldb-dap) and retry.<br/><br/>" +
+                                "driver=$dapDriverPath$detail",
+                            NotificationType.ERROR
+                        )
+                        .notify(project)
+                    throw Exception("GDB does not support DAP: $dapDriverPath")
                 }
                 
                 Logger.v(TAG, "Using DAP driver: $dapDriverPath ($driverName)")

--- a/src/main/kotlin/io/xmake/debug/XMakeDebugSession.kt
+++ b/src/main/kotlin/io/xmake/debug/XMakeDebugSession.kt
@@ -184,7 +184,7 @@ class XMakeDebugSession(private val state: RunProfileState, private val environm
                 val dapDriverPath = configuration.getEffectiveDapDriverPath()
                 if (dapDriverPath.isBlank()) {
                     Logger.e(TAG, "No DAP driver found")
-                    throw Exception("No DAP driver found. Please install lldb-dap or gdb-dap, or specify a custom path in the debug configuration.")
+                    throw Exception("No DAP driver found. Please install lldb-dap or gdb (with DAP support), or specify a custom path in the debug configuration.")
                 }
                 
                 // Get driver name from DapDriverDetector

--- a/src/main/kotlin/io/xmake/run/XMakeRunConfiguration.kt
+++ b/src/main/kotlin/io/xmake/run/XMakeRunConfiguration.kt
@@ -239,7 +239,33 @@ class XMakeRunConfiguration(
 
     companion object {
         
-        fun getDefaultLaunchConfigJson(): String {
+        fun getDefaultGdbLaunchConfigJson(): String {
+            return """{
+    "stopOnEntry": true,
+    "sourceMap": {
+        "enabled": "true"
+    },
+    "showDisassembly": "auto",
+    "setupCommands": [
+        {
+            "description": "Enable pretty-printing for gdb",
+            "text": "-enable-pretty-printing",
+            "ignoreFailures": true
+        }
+    ],
+    "variables": {
+        "showArguments": true,
+        "showLocals": true,
+        "showGlobals": true,
+        "showStatics": true,
+        "showRegisters": true
+    },
+    "ignoreFunctionBpoints": false,
+    "stopAtConnectTime": false
+}"""
+        }
+
+        fun getDefaultLldbLaunchConfigJson(): String {
             return """{
     "stopOnEntry": true,
     "sourceMap": {
@@ -247,14 +273,23 @@ class XMakeRunConfiguration(
     },
     "showDisassembly": "auto",
     "initCommands": [],
+    "preRunTask": {
+        "commands": []
+    },
     "variables": {
         "showArguments": true,
         "showLocals": true,
         "showGlobals": true,
         "showStatics": true,
         "showRegisters": true
-    }
+    },
+    "ignoreFunctionBpoints": false,
+    "stopAtConnectTime": false
 }"""
+        }
+
+        fun getDefaultLaunchConfigJson(): String {
+            return getDefaultLldbLaunchConfigJson()
         }
     }
 }

--- a/src/main/kotlin/io/xmake/run/XMakeRunConfigurationEditor.kt
+++ b/src/main/kotlin/io/xmake/run/XMakeRunConfigurationEditor.kt
@@ -52,7 +52,6 @@ import io.xmake.utils.execute.transferFolderByToolkit
 import io.xmake.utils.info.XMakeInfo
 import io.xmake.debug.DapDriverDetector
 import io.xmake.utils.info.XMakeInfoManager
-import io.xmake.utils.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch

--- a/src/main/kotlin/io/xmake/run/XMakeRunConfigurationEditor.kt
+++ b/src/main/kotlin/io/xmake/run/XMakeRunConfigurationEditor.kt
@@ -235,7 +235,7 @@ class XMakeRunConfigurationEditor(
         textField.isEditable = true
         addBrowseFolderListener(
             "Select DAP Driver",
-            "Select the DAP driver executable (lldb-dap or gdb-dap)",
+            "Select the DAP driver executable (lldb-dap or gdb)",
             project,
             FileChooserDescriptorFactory.createSingleFileDescriptor()
         )

--- a/src/main/kotlin/io/xmake/run/XMakeRunConfigurationEditor.kt
+++ b/src/main/kotlin/io/xmake/run/XMakeRunConfigurationEditor.kt
@@ -52,6 +52,7 @@ import io.xmake.utils.execute.transferFolderByToolkit
 import io.xmake.utils.info.XMakeInfo
 import io.xmake.debug.DapDriverDetector
 import io.xmake.utils.info.XMakeInfoManager
+import io.xmake.utils.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -295,18 +296,48 @@ class XMakeRunConfigurationEditor(
         dapDriverPathComboBox.isEnabled = !isAutoDetect
         dapDriverPathCustomField.isEnabled = !isAutoDetect
         
+        // Initial update of launch configuration based on effective driver
+        val effectivePath = configuration.getEffectiveDapDriverPath()
+        // If the configuration is blank, we must initialize it with the correct default
+        // based on the effective driver (which might be GDB or LLDB).
+        // If it's not blank, we leave it alone (it's user's saved state).
+        if (launchConfiguration.text.isBlank() && effectivePath.isNotBlank()) {
+            val availableDrivers = configuration.getAvailableDapDrivers()
+            val driver = availableDrivers.find { it.path == effectivePath }
+            if (driver != null) {
+                 if (driver.type.displayName.contains("gdb", ignoreCase = true)) {
+                    launchConfiguration.text = XMakeRunConfiguration.getDefaultGdbLaunchConfigJson()
+                } else {
+                    launchConfiguration.text = XMakeRunConfiguration.getDefaultLldbLaunchConfigJson()
+                }
+            }
+        }
+        
         // Add DAP driver checkbox listener
         dapDriverAutoDetectCheckBox.addItemListener {
             val isAutoDetect = dapDriverAutoDetectCheckBox.isSelected
             dapDriverPathComboBox.isEnabled = !isAutoDetect
             dapDriverPathCustomField.isEnabled = !isAutoDetect
+
+            if (isAutoDetect) {
+                // If auto-detect is enabled, find the best driver and update config
+                val bestDriver = io.xmake.debug.DapDriverDetector.findBestDriver()
+                if (bestDriver != null) {
+                    updateLaunchConfigurationForDriver(bestDriver.type.displayName)
+                }
+            }
         }
         
         // Add DAP driver combo box listener
         dapDriverPathComboBox.addItemListener {
-            val selectedDriver = runConfiguration.getAvailableDapDrivers().getOrNull(dapDriverPathComboBox.selectedIndex)
-            if (selectedDriver != null) {
-                dapDriverPathCustomField.text = selectedDriver.path
+            if (it.stateChange == java.awt.event.ItemEvent.SELECTED) {
+                val selectedDriver = runConfiguration.getAvailableDapDrivers().getOrNull(dapDriverPathComboBox.selectedIndex)
+                if (selectedDriver != null) {
+                    dapDriverPathCustomField.text = selectedDriver.path
+                    if (!dapDriverAutoDetectCheckBox.isSelected) {
+                        updateLaunchConfigurationForDriver(selectedDriver.type.displayName)
+                    }
+                }
             }
         }
     }
@@ -504,6 +535,14 @@ class XMakeRunConfigurationEditor(
             val toolkit = (it as? ToolkitListItem.ToolkitItem)?.toolkit
             toolkit?.isOnRemote ?: false
         })
+    }
+
+    private fun updateLaunchConfigurationForDriver(driverName: String) {
+        if (driverName.contains("gdb", ignoreCase = true)) {
+            launchConfiguration.text = XMakeRunConfiguration.getDefaultGdbLaunchConfigJson()
+        } else {
+            launchConfiguration.text = XMakeRunConfiguration.getDefaultLldbLaunchConfigJson()
+        }
     }
 
     private fun JPanel.makeWide() {

--- a/src/main/kotlin/io/xmake/utils/Logger.kt
+++ b/src/main/kotlin/io/xmake/utils/Logger.kt
@@ -28,112 +28,114 @@ import com.intellij.openapi.diagnostic.logger
  * Uses println in debug mode and IntelliJ logger in production
  */
 object Logger {
-    
+
     // Log levels
     enum class LogLevel {
         DEBUG,
-        VERBOSE, 
+        VERBOSE,
         INFO,
         WARN,
         ERROR
     }
-    
+
     // Default tag
     private const val DEFAULT_TAG = "XMake"
-    
+
     // Use IntelliJ logger in production, println in debug
-    private val useIntelliJLogger = java.lang.Boolean.getBoolean("xmake.production") && !java.lang.Boolean.getBoolean("xmake.debug")
-    
+    //private val useIntelliJLogger = java.lang.Boolean.getBoolean("xmake.production") && !java.lang.Boolean.getBoolean("xmake.debug")
+    private val useIntelliJLogger = true
+
     // Current log level (can be configured)
-    private var currentLogLevel = if (useIntelliJLogger) LogLevel.INFO else LogLevel.DEBUG
-    
+    //private var currentLogLevel = if (useIntelliJLogger) LogLevel.INFO else LogLevel.DEBUG
+    private var currentLogLevel = LogLevel.DEBUG
+
     // IntelliJ logger instances
     private val loggers = mutableMapOf<String, com.intellij.openapi.diagnostic.Logger>()
-    
+
     /**
      * Set the current log level
      */
     fun setLogLevel(level: LogLevel) {
         currentLogLevel = level
     }
-    
+
     /**
      * Get current logging mode (for debugging)
      */
     fun getLoggingMode(): String {
         return if (useIntelliJLogger) "IntelliJ Logger" else "Console (println)"
     }
-    
+
     /**
      * Debug level log
      */
     fun d(tag: String = DEFAULT_TAG, message: String) {
         log(LogLevel.DEBUG, tag, message)
     }
-    
+
     /**
      * Debug level log with default tag
      */
     fun d(message: String) {
         d(DEFAULT_TAG, message)
     }
-    
+
     /**
      * Verbose level log
      */
     fun v(tag: String = DEFAULT_TAG, message: String) {
         log(LogLevel.VERBOSE, tag, message)
     }
-    
+
     /**
      * Verbose level log with default tag
      */
     fun v(message: String) {
         v(DEFAULT_TAG, message)
     }
-    
+
     /**
      * Info level log (default)
      */
     fun i(tag: String = DEFAULT_TAG, message: String) {
         log(LogLevel.INFO, tag, message)
     }
-    
+
     /**
      * Info level log with default tag
      */
     fun i(message: String) {
         i(DEFAULT_TAG, message)
     }
-    
+
     /**
      * Warning level log
      */
     fun w(tag: String = DEFAULT_TAG, message: String) {
         log(LogLevel.WARN, tag, message)
     }
-    
+
     /**
      * Warning level log with default tag
      */
     fun w(message: String) {
         w(DEFAULT_TAG, message)
     }
-    
+
     /**
      * Error level log
      */
     fun e(tag: String = DEFAULT_TAG, message: String) {
         log(LogLevel.ERROR, tag, message)
     }
-    
+
     /**
      * Error level log with default tag
      */
     fun e(message: String) {
         e(DEFAULT_TAG, message)
     }
-    
+
     /**
      * Error level log with exception
      */
@@ -145,14 +147,14 @@ object Logger {
             throwable.printStackTrace()
         }
     }
-    
+
     /**
      * Error level log with exception and default tag
      */
     fun e(message: String, throwable: Throwable) {
         e(DEFAULT_TAG, message, throwable)
     }
-    
+
     /**
      * Core logging method - chooses between println and IntelliJ logger
      */
@@ -160,7 +162,7 @@ object Logger {
         if (level.ordinal < currentLogLevel.ordinal) {
             return
         }
-        
+
         if (useIntelliJLogger) {
             // Use IntelliJ logger in production
             val logger = getLogger(tag)
@@ -176,7 +178,7 @@ object Logger {
             val timestamp = java.time.LocalDateTime.now().format(
                 java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
             )
-            
+
             val levelChar = when (level) {
                 LogLevel.DEBUG -> "D"
                 LogLevel.VERBOSE -> "V"
@@ -184,11 +186,11 @@ object Logger {
                 LogLevel.WARN -> "W"
                 LogLevel.ERROR -> "E"
             }
-            
+
             println("[$timestamp] $levelChar/$tag: $message")
         }
     }
-    
+
     /**
      * Get or create IntelliJ logger for the given tag
      */

--- a/src/main/kotlin/io/xmake/utils/info/XMakeInfo.kt
+++ b/src/main/kotlin/io/xmake/utils/info/XMakeInfo.kt
@@ -20,7 +20,7 @@
  */
 package io.xmake.utils.info
 
-import com.intellij.openapi.diagnostic.logger
+import io.xmake.utils.Logger
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.JsonObject
@@ -60,7 +60,7 @@ class XMakeInfo {
             }
             architectures
         } catch (e: Exception) {
-            Log.error("Failed to parse architectures: $e")
+            Logger.e("Failed to parse architectures: $e")
             emptyMap()
         }
     }
@@ -76,7 +76,7 @@ class XMakeInfo {
             val modes = buildModeString.split("\n").map { it.trim() }.filter { it.isNotEmpty() }
             modes
         } catch (e: Exception) {
-            Log.error("Failed to parse buildmodes: $e")
+            Logger.e("Failed to parse buildmodes: $e")
             emptyList()
         }
     }
@@ -92,7 +92,7 @@ class XMakeInfo {
             val platforms = platformString.split("\n").map { it.trim() }.filter { it.isNotEmpty() }
             platforms
         } catch (e: Exception) {
-            Log.error("Failed to parse platforms: $e")
+            Logger.e("Failed to parse platforms: $e")
             emptyList()
         }
     }
@@ -108,7 +108,7 @@ class XMakeInfo {
             val targets = targetString.split("\n").map { it.trim() }.filter { it.isNotEmpty() }
             targets
         } catch (e: Exception) {
-            Log.error("Failed to parse targets: $e")
+            Logger.w("Failed to parse targets: $e")
             emptyList()
         }
     }
@@ -144,7 +144,7 @@ class XMakeInfo {
                  } else null
              }.associate { it }
         } catch (e: Exception) {
-            Log.error("Failed to parse toolchains: $e")
+            Logger.w("Failed to parse toolchains: $e")
             emptyMap()
         }
     }
@@ -168,14 +168,9 @@ class XMakeInfo {
                 return apis
             }
         } catch (e: Exception) {
-            Log.error("Failed to parse apis: $e")
+            Logger.w("Failed to parse apis: $e")
         }
         return emptySet()
-    }
-
-    companion object {
-        val Log = logger<XMakeInfo>()
-
     }
 }
 

--- a/src/main/kotlin/io/xmake/utils/info/XMakeInfo.kt
+++ b/src/main/kotlin/io/xmake/utils/info/XMakeInfo.kt
@@ -60,7 +60,7 @@ class XMakeInfo {
             }
             architectures
         } catch (e: Exception) {
-            Logger.e("Failed to parse architectures: $e")
+            Logger.e("Failed to parse architectures: $e\n$archString")
             emptyMap()
         }
     }
@@ -76,7 +76,7 @@ class XMakeInfo {
             val modes = buildModeString.split("\n").map { it.trim() }.filter { it.isNotEmpty() }
             modes
         } catch (e: Exception) {
-            Logger.e("Failed to parse buildmodes: $e")
+            Logger.e("Failed to parse buildmodes: $e\n$buildModeString")
             emptyList()
         }
     }
@@ -92,7 +92,7 @@ class XMakeInfo {
             val platforms = platformString.split("\n").map { it.trim() }.filter { it.isNotEmpty() }
             platforms
         } catch (e: Exception) {
-            Logger.e("Failed to parse platforms: $e")
+            Logger.e("Failed to parse platforms: $e\n$platformString")
             emptyList()
         }
     }
@@ -108,7 +108,7 @@ class XMakeInfo {
             val targets = targetString.split("\n").map { it.trim() }.filter { it.isNotEmpty() }
             targets
         } catch (e: Exception) {
-            Logger.w("Failed to parse targets: $e")
+            Logger.w("Failed to parse targets: $e\n$targetString")
             emptyList()
         }
     }
@@ -144,7 +144,7 @@ class XMakeInfo {
                  } else null
              }.associate { it }
         } catch (e: Exception) {
-            Logger.w("Failed to parse toolchains: $e")
+            Logger.w("Failed to parse toolchains: $e\n$toolchainString")
             emptyMap()
         }
     }
@@ -168,7 +168,7 @@ class XMakeInfo {
                 return apis
             }
         } catch (e: Exception) {
-            Logger.w("Failed to parse apis: $e")
+            Logger.w("Failed to parse apis: $e\n$apiString")
         }
         return emptySet()
     }


### PR DESCRIPTION
We need to use `-gdwarf-4` to build debug program on macOS.

```lua
        add_cxflags("-gdwarf-4", {force = true})
```

lldb-dap.exe works fine on windows. But we need to fix some missing dll deps manually. 

lldb-dap.exe/liblldb.dll need to load python310.dll, we need to add it to $PATH.

Note: The current patch has not yet successfully run gdb dap, but it has already done a lot of adaptation.