### PR TITLE
Keep plugin verification at root artifact

### DIFF
--- a/clion-debug/build.gradle.kts
+++ b/clion-debug/build.gradle.kts
@@ -37,6 +37,11 @@ tasks.matching { task -> task.name.contains("runIde") }.configureEach {
     enabled = false
 }
 
+// The root plugin artifact is the verifier boundary; this module is packaged into it.
+tasks.matching { task -> task.name == "verifyPlugin" }.configureEach {
+    enabled = false
+}
+
 tasks {
     compileKotlin {
         compilerOptions.jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)


### PR DESCRIPTION
 **Keep plugin verification at the root artifact — disable redundant `verifyPlugin` in `clion-debug`.**

  ## _What Changed_

  - Disabled the `verifyPlugin` task in `clion-debug/build.gradle.kts`.

  ## _Why_

  `clion-debug` is packaged into the root plugin artifact — it is not a standalone plugin. Running `verifyPlugin` inside `clion-debug` would redundantly validate the same artifact, adding noise and build time without additional safety. Disabling it at the submodule level ensures verification happens once, at the correct boundary: the root artifact.

  ## _Impact_

  _Plugin verification now runs exactly once, at the root artifact, matching the actual release boundary._

  _No change to the clion-debug module's compilation, packaging, or runtime behavior — it remains part of the root build as before._
