### PR TITLE
Prefer project repository defaults for dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,11 +18,7 @@ plugins {
 group = "io.xmake"
 
 repositories {
-    maven("https://maven.aliyun.com/repository/public/")
-    maven("https://oss.sonatype.org/content/repositories/snapshots/")
-    mavenLocal()
     mavenCentral()
-    gradlePluginPortal()
     intellijPlatform {
         defaultRepositories()
     }


### PR DESCRIPTION
 **Removed explicit repository declarations — kept only `mavenCentral` and `intellijPlatform` defaults**

  ## _What Changed_
  - Removed `maven("https://maven.aliyun.com/repository/public/")` from `build.gradle.kts` repositories block
  - Removed `maven("https://oss.sonatype.org/content/repositories/snapshots/")` from `build.gradle.kts` repositories block
  - Removed `mavenLocal()` from `build.gradle.kts` repositories block
  - Removed `gradlePluginPortal()` from `build.gradle.kts` repositories block
  
  ## _Why_
  - `gradlePluginPortal()` is already covered by Gradle's built-in plugin resolution mechanism and should not appear as a dependency repository.
  - `mavenLocal()` participates in Gradle's default resolution chain automatically — explicit declaration is redundant.
  - `maven("https://oss.sonatype.org/content/repositories/snapshots/")` has **no matching snapshot artifacts** in the project's current dependency graph; keeping it introduces unnecessary network round-trips.
  - `maven("https://maven.aliyun.com/repository/public/")` was added as a regional-network workaround. Hardcoding it in source control **leaks a developer-local concern into the shared build file**, with significant downstream impact on CI: when the CI runner is on a network that can reach Aliyun, the mirror sits ahead of `mavenCentral` and resolves *silently*; when the CI runner migrates to a different region or network policy changes, the Aliyun mirror may become unreachable or high-latency, causing dependency resolution to *degrade silently rather than failing fast*.
   Removing it makes CI resolution behavior **predictable and auditable** — the same `mavenCentral` baseline applies everywhere, and mirrors are injected via `~/.gradle/init.gradle` or CI-runner global Gradle configuration instead of being committed into the repository.

  ## _Impact_
  _CI dependency resolution is now fully controlled by the runner environment — domestic CI runners can inject the Aliyun mirror via global Gradle configuration, while overseas runners hit `mavenCentral` directly, with no interference from a hardcoded mirror order in the build file._
  _CI environment changes (runner migration, network zone switching) no longer risk silent regression caused by the committed Aliyun declaration, reducing timeout or failure incidents tied to mirror unreachability._
  _All developers share the same resolution baseline as CI; developers who need mirrors configure them locally through `init.gradle`, keeping the shared build file clean._

