### PR TITLE
Use the registered XMake tool window

### DIFF
--- a/src/main/kotlin/io/xmake/actions/QuickStartAction.kt
+++ b/src/main/kotlin/io/xmake/actions/QuickStartAction.kt
@@ -22,8 +22,8 @@ package io.xmake.actions
 
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.OSProcessHandler
-import com.intellij.execution.process.ProcessAdapter
 import com.intellij.execution.process.ProcessEvent
+import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
@@ -32,11 +32,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtil
-import com.intellij.openapi.wm.RegisterToolWindowTask
-import com.intellij.openapi.wm.ToolWindowAnchor
 import com.intellij.openapi.wm.ToolWindowManager
-import io.xmake.icons.XMakeIcons
-import io.xmake.project.XMakeToolWindowFactory
 import io.xmake.project.toolkit.activatedToolkit
 import io.xmake.project.xmakeConsoleView
 import io.xmake.shared.xmakeConfiguration
@@ -53,7 +49,6 @@ class QuickStartAction : AnAction() {
             return
         }
         e.presentation.isVisible = true
-        // Disable in xmake project (grayed out)
         e.presentation.isEnabled = !SystemUtils.isXMakeProject(project)
     }
 
@@ -69,8 +64,10 @@ class QuickStartAction : AnAction() {
 
             try {
                 val processHandler = OSProcessHandler(commandLine)
-                processHandler.addProcessListener(object : ProcessAdapter() {
+                processHandler.addProcessListener(object : ProcessListener {
                     override fun processTerminated(event: ProcessEvent) {
+                        if (project.isDisposed) return
+
                         if (event.exitCode == 0) {
                             NotificationGroupManager.getInstance()
                                 .getNotificationGroup("XMake.NotificationGroup")
@@ -78,6 +75,8 @@ class QuickStartAction : AnAction() {
                                 .notify(project)
 
                             ApplicationManager.getApplication().invokeLater {
+                                if (project.isDisposed) return@invokeLater
+
                                 // Refresh VFS
                                 project.basePath?.let { path ->
                                     val file = LocalFileSystem.getInstance().findFileByPath(path)
@@ -87,24 +86,9 @@ class QuickStartAction : AnAction() {
                                 }
 
                                 // Show Tool Window
-                                val toolWindowManager = ToolWindowManager.getInstance(project)
-                                var toolWindow = toolWindowManager.getToolWindow("XMake")
-                                if (toolWindow == null) {
-                                    val task = RegisterToolWindowTask(
-                                        id = "XMake",
-                                        anchor = ToolWindowAnchor.BOTTOM,
-                                        component = null,
-                                        canCloseContent = true,
-                                        canWorkInDumbMode = true,
-                                        shouldBeAvailable = true,
-                                        contentFactory = null,
-                                        icon = XMakeIcons.XMAKE,
-                                        stripeTitle = null
-                                    )
-                                    toolWindow = toolWindowManager.registerToolWindow(task)
-                                    XMakeToolWindowFactory().createToolWindowContent(project, toolWindow)
-                                }
-                                toolWindow.show(null)
+                                ToolWindowManager.getInstance(project)
+                                    .getToolWindow("XMake")
+                                    ?.show(null)
                             }
                         } else {
                             NotificationGroupManager.getInstance()

--- a/src/main/kotlin/io/xmake/project/XMakeToolWindowFactory.kt
+++ b/src/main/kotlin/io/xmake/project/XMakeToolWindowFactory.kt
@@ -21,33 +21,27 @@
 package io.xmake.project
 
 import com.intellij.execution.ui.ConsoleView
+import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.ui.content.ContentFactory
 import io.xmake.shared.XMakeProblem
-import io.xmake.utils.SystemUtils
+import kotlin.jvm.JvmDefaultWithoutCompatibility
 
-class XMakeToolWindowFactory : ToolWindowFactory {
-
-    override fun isApplicable(project: Project): Boolean {
-        return SystemUtils.isXMakeProject(project)
-    }
+@JvmDefaultWithoutCompatibility
+class XMakeToolWindowFactory : ToolWindowFactory, DumbAware {
 
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
-
-        // add output tab/panel
-        val toolwindowOutputPanel = XMakeToolWindowOutputPanel(project)
-        val outputTab = ContentFactory.getInstance().createContent(toolwindowOutputPanel, "Output", false)
+        val outputPanel = XMakeToolWindowOutputPanel(project)
+        val outputTab = ContentFactory.getInstance().createContent(outputPanel, "Output", false)
         toolWindow.contentManager.addContent(outputTab)
 
-        // add problem tab/panel
-        val toolwindowProblemPanel = XMakeToolWindowProblemPanel(project)
-        val problemTab = ContentFactory.getInstance().createContent(toolwindowProblemPanel, "Problem", false)
+        val problemPanel = XMakeToolWindowProblemPanel(project)
+        val problemTab = ContentFactory.getInstance().createContent(problemPanel, "Problem", false)
         toolWindow.contentManager.addContent(problemTab)
 
-        // show the output panel by default
         toolWindow.contentManager.setSelectedContent(outputTab)
     }
 }


### PR DESCRIPTION
**Removed runtime XMake tool window registration - relied on the descriptor-registered tool window**

## _What Changed_
- Updated `QuickStartAction` to use `ProcessListener` and retrieve only the descriptor-registered XMake tool window.
- Removed the fallback `RegisterToolWindowTask` registration path from `QuickStartAction`.
- Updated `XMakeToolWindowFactory` to implement `DumbAware` and rely on descriptor-based tool window creation.
- Simplified the tool window content setup for the `Output` and `Problem` tabs.

## _Why_
- The XMake tool window is already registered through `plugin.xml`, so registering it again at runtime creates **two competing ownership paths** for the same tool window.
- Runtime fallback registration can bypass the lifecycle managed by the IntelliJ Platform and can produce inconsistent availability or duplicate initialization.
- Relying on the registered `ToolWindowFactory` keeps creation *declarative* and makes `QuickStartAction` responsible only for showing the existing tool window.

## _Impact_
*The XMake tool window now has a single descriptor-owned lifecycle and is shown only after the platform has registered it.*
*Quick Start behavior remains unchanged for users, while duplicate registration and initialization paths are removed.*