### PR TITLE
Resolve compatibility and synchronization issues

### DIFF
--- a/src/main/kotlin/io/xmake/actions/UpdateCmakeListsAction.kt
+++ b/src/main/kotlin/io/xmake/actions/UpdateCmakeListsAction.kt
@@ -25,7 +25,6 @@ import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
-import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import io.xmake.project.toolkit.activatedToolkit
 import io.xmake.project.xmakeConsoleView
@@ -46,38 +45,41 @@ class UpdateCmakeListsAction : XMakeBaseAction() {
         try {
             // configure and build it
             val xmakeConfiguration = project.xmakeConfiguration
-            if (xmakeConfiguration.changed) {
-                SystemUtils.runvInConsole(project, xmakeConfiguration.configurationCommandLine)
-                    ?.addProcessListener(object : ProcessListener {
-                        override fun processTerminated(e: ProcessEvent) {
-                            syncBeforeFetch(project, project.activatedToolkit!!)
+            val updateCmakeLists = update@{
+                if (project.isDisposed) return@update
+                val toolkit = project.activatedToolkit ?: return@update
 
-                            SystemUtils.runvInConsole(
-                                project,
-                                xmakeConfiguration.updateCmakeListsCommandLine,
-                                false,
-                                true,
-                                true
-                            )?.addProcessListener(
-                                object : ProcessListener {
-                                    override fun processTerminated(e: ProcessEvent) {
-                                        fetchGeneratedFile(project, project.activatedToolkit!!, "CMakeLists.txt")
-                                        // Todo: Reload from disks after download from remote.
-                                    }
-                                }
-                            )
-                        }
-                    })
-                xmakeConfiguration.changed = false
-            } else {
-                SystemUtils.runvInConsole(project, xmakeConfiguration.updateCmakeListsCommandLine, false, true, true)
-                    ?.addProcessListener(
-                        object : ProcessListener{
-                            override fun processTerminated(e: ProcessEvent) {
-                                fetchGeneratedFile(project, project.activatedToolkit!!, "CMakeLists.txt")
+                syncBeforeFetch(project, toolkit) sync@{
+                    if (project.isDisposed) return@sync
+
+                    SystemUtils.runvInConsole(
+                        project,
+                        xmakeConfiguration.updateCmakeListsCommandLine,
+                        false,
+                        true,
+                        true
+                    )?.addProcessListener(
+                        object : ProcessListener {
+                            override fun processTerminated(event: ProcessEvent) {
+                                if (project.isDisposed || event.exitCode != 0) return
+                                fetchGeneratedFile(project, toolkit, "CMakeLists.txt")
                             }
                         }
                     )
+                }
+            }
+
+            if (xmakeConfiguration.changed) {
+                SystemUtils.runvInConsole(project, xmakeConfiguration.configurationCommandLine)
+                    ?.addProcessListener(object : ProcessListener {
+                        override fun processTerminated(event: ProcessEvent) {
+                            if (project.isDisposed || event.exitCode != 0) return
+                            xmakeConfiguration.changed = false
+                            updateCmakeLists()
+                        }
+                    })
+            } else {
+                updateCmakeLists()
             }
         } catch (e: XMakeRunConfigurationNotSetException) {
             project.xmakeConsoleView.print(

--- a/src/main/kotlin/io/xmake/actions/UpdateCompileCommandsAction.kt
+++ b/src/main/kotlin/io/xmake/actions/UpdateCompileCommandsAction.kt
@@ -26,7 +26,6 @@ import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
-import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runWriteAction
@@ -50,49 +49,29 @@ class UpdateCompileCommandsAction : XMakeBaseAction() {
         try {
             // configure and build it
             val xmakeConfiguration = project.xmakeConfiguration
-            if (xmakeConfiguration.changed) {
-                SystemUtils.runvInConsole(project, xmakeConfiguration.configurationCommandLine)
-                    ?.addProcessListener(object : ProcessListener {
-                        override fun processTerminated(e: ProcessEvent) {
-                            project.activatedToolkit?.let { syncBeforeFetch(project, it) }
+            val updateCompileCommands = update@{
+                if (project.isDisposed) return@update
+                val toolkit = project.activatedToolkit
 
-                            SystemUtils.runvInConsole(
-                                project,
-                                xmakeConfiguration.updateCompileCommandsLine,
-                                false,
-                                true,
-                                true
-                            )
-                                ?.addProcessListener(
-                                    object : ProcessListener {
-                                        override fun processTerminated(e: ProcessEvent) {
-                                            val toolkit = project.activatedToolkit
-                                            if (toolkit != null) {
-                                                fetchGeneratedFile(project, toolkit, "compile_commands.json")
-                                            } else {
-                                                ApplicationManager.getApplication().invokeLater {
-                                                    runWriteAction {
-                                                        VirtualFileManager.getInstance().syncRefresh()
-                                                    }
-                                                }
-                                            }
-                                            // Todo: Reload from disks after download from remote.
-                                        }
-                                    }
-                                )
-                        }
-                    })
-                xmakeConfiguration.changed = false
-            } else {
-                SystemUtils.runvInConsole(project, xmakeConfiguration.updateCompileCommandsLine, false, true, true)
-                    ?.addProcessListener(
+                val launchUpdate = launch@{
+                    if (project.isDisposed) return@launch
+
+                    SystemUtils.runvInConsole(
+                        project,
+                        xmakeConfiguration.updateCompileCommandsLine,
+                        false,
+                        true,
+                        true
+                    )?.addProcessListener(
                         object : ProcessListener {
-                            override fun processTerminated(e: ProcessEvent) {
-                                val toolkit = project.activatedToolkit
+                            override fun processTerminated(event: ProcessEvent) {
+                                if (project.isDisposed || event.exitCode != 0) return
+
                                 if (toolkit != null) {
                                     fetchGeneratedFile(project, toolkit, "compile_commands.json")
                                 } else {
                                     ApplicationManager.getApplication().invokeLater {
+                                        if (project.isDisposed) return@invokeLater
                                         runWriteAction {
                                             VirtualFileManager.getInstance().syncRefresh()
                                         }
@@ -101,6 +80,26 @@ class UpdateCompileCommandsAction : XMakeBaseAction() {
                             }
                         }
                     )
+                }
+
+                if (toolkit != null) {
+                    syncBeforeFetch(project, toolkit) { launchUpdate() }
+                } else {
+                    launchUpdate()
+                }
+            }
+
+            if (xmakeConfiguration.changed) {
+                SystemUtils.runvInConsole(project, xmakeConfiguration.configurationCommandLine)
+                    ?.addProcessListener(object : ProcessListener {
+                        override fun processTerminated(event: ProcessEvent) {
+                            if (project.isDisposed || event.exitCode != 0) return
+                            xmakeConfiguration.changed = false
+                            updateCompileCommands()
+                        }
+                    })
+            } else {
+                updateCompileCommands()
             }
         } catch (e: XMakeRunConfigurationNotSetException) {
             project.xmakeConsoleView.print(

--- a/src/main/kotlin/io/xmake/project/toolkit/ToolkitManager.kt
+++ b/src/main/kotlin/io/xmake/project/toolkit/ToolkitManager.kt
@@ -25,8 +25,10 @@ import com.intellij.execution.processTools.getBareExecutionResult
 import com.intellij.execution.wsl.WSLDistribution
 import com.intellij.execution.wsl.WSLUtil
 import com.intellij.execution.wsl.WslDistributionManager
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.*
 import com.intellij.openapi.extensions.ExtensionPointName
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.util.system.OS
@@ -69,25 +71,44 @@ class ToolkitManager(private val scope: CoroutineScope) : PersistentStateCompone
     init {
         scope.launch {
             // Cache the list of installed distributions
-            WslDistributionManager.getInstance().installedDistributions
+            getInstalledWslDistributions()
         }
     }
 
     private fun toolkitHostFlow(project: Project? = null): Flow<ToolkitHost> = flow {
-        val wslDistributions = scope.async { WslDistributionManager.getInstance().installedDistributions }
+        val wslDistributions = scope.async { getInstalledWslDistributions() }
 
         emit(ToolkitHost(LOCAL).also { host -> Logger.i(TAG, "emit host: $host") })
 
-        if (WSLUtil.isSystemCompatible()) {
-            wslDistributions.await().forEach {
-                emit(ToolkitHost(WSL, it).also { host -> Logger.i(TAG, "emit host: $host") })
-            }
+        wslDistributions.await().forEach {
+            emit(ToolkitHost(WSL, it).also { host -> Logger.i(TAG, "emit host: $host") })
         }
 
         EP_NAME.extensions.filter { it.KEY == "SSH" }.forEach {
             it.getToolkitHosts(project).forEach {
                 emit(it).also { host -> Logger.i(TAG, "emit host: $host") }
             }
+        }
+    }
+
+    private fun getInstalledWslDistributions(): List<WSLDistribution> {
+        if (ApplicationManager.getApplication() == null) {
+            return emptyList()
+        }
+
+        if (!WSLUtil.isSystemCompatible()) {
+            return emptyList()
+        }
+
+        return try {
+            WslDistributionManager.getInstance().installedDistributions
+        } catch (e: ProcessCanceledException) {
+            throw e
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Logger.w(TAG, e.message ?: "Failed to read WSL distributions")
+            emptyList()
         }
     }
 

--- a/src/main/kotlin/io/xmake/utils/execute/Sync.kt
+++ b/src/main/kotlin/io/xmake/utils/execute/Sync.kt
@@ -24,12 +24,11 @@ import com.intellij.execution.RunManager
 import com.intellij.execution.wsl.WSLDistribution
 import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.diagnostic.fileLogger
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.progress.ProgressIndicator
-import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
-import com.intellij.openapi.progress.util.ProgressIndicatorBase
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.util.io.toCanonicalPath
@@ -41,7 +40,6 @@ import io.xmake.run.XMakeRunConfiguration
 import io.xmake.utils.extension.ToolkitHostExtension
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import java.nio.file.FileVisitResult
 import java.nio.file.Files
 import java.nio.file.NoSuchFileException
@@ -51,6 +49,8 @@ import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
 import kotlin.io.path.Path
+
+private val Log = fileLogger()
 
 private val EP_NAME: ExtensionPointName<ToolkitHostExtension> = ExtensionPointName("io.xmake.toolkitHostExtension")
 
@@ -77,35 +77,39 @@ fun syncProjectByWslSync(
     direction: SyncDirection,
     directoryPath: String,
     relativePath: String? = null,
+    onComplete: () -> Unit = {},
 ) {
     val wslDistribution = host.target as? WSLDistribution ?: throw IllegalArgumentException()
 
-    ProgressManager.getInstance().runProcessWithProgressAsynchronously(
-        object : Task.Backgroundable(project, "Sync directory", true) {
-            override fun run(indicator: ProgressIndicator) {
-                indicator.isIndeterminate = true
-                indicator.text = "Syncing WSL files"
+    object : Task.Backgroundable(project, "Sync directory", true) {
+        override fun run(indicator: ProgressIndicator) {
+            indicator.isIndeterminate = true
+            indicator.text = "Syncing WSL files"
 
-                val localRoot = project.guessProjectDir()?.toNioPath()
-                    ?: project.basePath?.let { Path(it) }
-                    ?: throw IllegalStateException("Cannot resolve project directory")
-                val upstreamRoot = Path(wslDistribution.toWindowsPath(directoryPath))
-                val syncPaths = resolveSyncPaths(localRoot, upstreamRoot, relativePath)
+            val localRoot = project.guessProjectDir()?.toNioPath()
+                ?: project.basePath?.let { Path(it) }
+                ?: throw IllegalStateException("Cannot resolve project directory")
+            val upstreamRoot = Path(wslDistribution.toWindowsPath(directoryPath))
+            val syncPaths = resolveSyncPaths(localRoot, upstreamRoot, relativePath)
 
-                runSyncWithVfsRefresh(syncAction = {
-                    when (direction) {
-                        SyncDirection.LOCAL_TO_UPSTREAM -> copyPath(syncPaths.local, syncPaths.upstream, indicator)
-                        SyncDirection.UPSTREAM_TO_LOCAL -> copyPath(syncPaths.upstream, syncPaths.local, indicator)
-                    }
-                })
+            runSyncWithVfsRefresh(syncAction = {
+                when (direction) {
+                    SyncDirection.LOCAL_TO_UPSTREAM -> copyPath(syncPaths.local, syncPaths.upstream, indicator)
+                    SyncDirection.UPSTREAM_TO_LOCAL -> copyPath(syncPaths.upstream, syncPaths.local, indicator)
+                }
+            })
+        }
+
+        override fun onSuccess() {
+            if (!project.isDisposed) {
+                onComplete()
             }
+        }
 
-            override fun onCancel() {}
-
-            override fun onFinished() {}
-        },
-        ProgressIndicatorBase()
-    )
+        override fun onThrowable(error: Throwable) {
+            Log.warn("Failed to sync WSL files", error)
+        }
+    }.queue()
 }
 
 private fun WSLDistribution.toWindowsPath(path: String): String {
@@ -245,11 +249,16 @@ fun transferFolderByToolkit(
     direction: SyncDirection,
     directoryPath: String = (RunManager.getInstance(project).selectedConfiguration?.configuration as XMakeRunConfiguration).runWorkingDir,
     relativePath: String? = null,
+    onComplete: () -> Unit = {},
 ) {
+    if (project.isDisposed) return
 
     when (toolkit.host.type) {
         ToolkitHostType.LOCAL -> {
             refreshVirtualFileSystem()
+            if (!project.isDisposed) {
+                onComplete()
+            }
         }
         ToolkitHostType.WSL -> {
             syncProjectByWslSync(
@@ -257,20 +266,27 @@ fun transferFolderByToolkit(
                 toolkit.host,
                 direction,
                 directoryPath,
-                relativePath
+                relativePath,
+                onComplete,
             )
         }
         ToolkitHostType.SSH -> {
             val path = relativePath?.let { Path(directoryPath).resolve(relativePath).toCanonicalPath() }
                 ?: directoryPath
             EP_NAME.extensions.first { it.KEY == "SSH" }
-                .syncProject(scope, project, toolkit.host, direction, path)
+                .syncProject(scope, project, toolkit.host, direction, path, onComplete)
         }
     }
 }
 
-fun syncBeforeFetch(project: Project, toolkit: Toolkit) {
-    transferFolderByToolkit(project, toolkit, SyncDirection.LOCAL_TO_UPSTREAM, relativePath = null)
+fun syncBeforeFetch(project: Project, toolkit: Toolkit, onComplete: () -> Unit = {}) {
+    transferFolderByToolkit(
+        project,
+        toolkit,
+        SyncDirection.LOCAL_TO_UPSTREAM,
+        relativePath = null,
+        onComplete = onComplete,
+    )
 }
 
 fun fetchGeneratedFile(project: Project, toolkit: Toolkit, fileRelatedPath: String) {

--- a/src/main/kotlin/io/xmake/utils/execute/Sync.kt
+++ b/src/main/kotlin/io/xmake/utils/execute/Sync.kt
@@ -21,17 +21,11 @@
 package io.xmake.utils.execute
 
 import com.intellij.execution.RunManager
-import com.intellij.execution.target.TargetEnvironment
-import com.intellij.execution.target.TargetProgressIndicatorAdapter
 import com.intellij.execution.wsl.WSLDistribution
-import com.intellij.execution.wsl.target.WslTargetEnvironment
-import com.intellij.execution.wsl.target.WslTargetEnvironmentConfiguration
-import com.intellij.execution.wsl.target.WslTargetEnvironmentRequest
-import com.intellij.openapi.application.EDT
 import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.application.runWriteAction
-import com.intellij.openapi.diagnostic.fileLogger
 import com.intellij.openapi.extensions.ExtensionPointName
+import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
@@ -40,7 +34,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.util.io.toCanonicalPath
 import com.intellij.openapi.vfs.VirtualFileManager
-import org.jetbrains.annotations.ApiStatus
 import io.xmake.project.toolkit.Toolkit
 import io.xmake.project.toolkit.ToolkitHost
 import io.xmake.project.toolkit.ToolkitHostType
@@ -49,11 +42,15 @@ import io.xmake.utils.extension.ToolkitHostExtension
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.NoSuchFileException
+import java.nio.file.Path as NioPath
+import java.nio.file.StandardCopyOption.COPY_ATTRIBUTES
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
 import kotlin.io.path.Path
-import kotlin.io.path.isDirectory
-
-private val Log = fileLogger()
 
 private val EP_NAME: ExtensionPointName<ToolkitHostExtension> = ExtensionPointName("io.xmake.toolkitHostExtension")
 
@@ -74,9 +71,7 @@ fun SyncDirection.toBoolean(): Boolean = when (this) {
     SyncDirection.UPSTREAM_TO_LOCAL -> true
 }
 
-@ApiStatus.Experimental
 fun syncProjectByWslSync(
-    scope: CoroutineScope,
     project: Project,
     host: ToolkitHost,
     direction: SyncDirection,
@@ -88,65 +83,21 @@ fun syncProjectByWslSync(
     ProgressManager.getInstance().runProcessWithProgressAsynchronously(
         object : Task.Backgroundable(project, "Sync directory", true) {
             override fun run(indicator: ProgressIndicator) {
-                scope.launch {
-                    indicator.isIndeterminate = true
+                indicator.isIndeterminate = true
+                indicator.text = "Syncing WSL files"
 
-                    /*                    for (i in 1..100) {
-                                            if (indicator.isCanceled) {
-                                                break
-                                            }
-                                            withContext(Dispatchers.EDT) {
-                                                indicator.fraction = i / 100.0
-                                                indicator.text = "Processing $i%"
-                                            }
-                                        }*/
+                val localRoot = project.guessProjectDir()?.toNioPath()
+                    ?: project.basePath?.let { Path(it) }
+                    ?: throw IllegalStateException("Cannot resolve project directory")
+                val upstreamRoot = Path(wslDistribution.toWindowsPath(directoryPath))
+                val syncPaths = resolveSyncPaths(localRoot, upstreamRoot, relativePath)
 
-                    val wslTargetEnvironmentRequest = WslTargetEnvironmentRequest(
-                        WslTargetEnvironmentConfiguration(wslDistribution)
-                    ).apply {
-                        downloadVolumes.add(
-                            TargetEnvironment.DownloadRoot(
-                                project.guessProjectDir()!!.toNioPath(),
-                                TargetEnvironment.TargetPath.Persistent(directoryPath)
-                            )
-                        )
-                        uploadVolumes.add(
-                            TargetEnvironment.UploadRoot(
-                                project.guessProjectDir()!!.toNioPath(),
-                                TargetEnvironment.TargetPath.Persistent(directoryPath),
-                            ).apply {
-                                this.volumeData
-                            }
-                        )
-                        shouldCopyVolumes = true
-                    }
-
-                    val wslTargetEnvironment = WslTargetEnvironment(
-                        wslTargetEnvironmentRequest,
-                        wslDistribution
-                    )
-
+                runSyncWithVfsRefresh(syncAction = {
                     when (direction) {
-                        SyncDirection.LOCAL_TO_UPSTREAM -> {
-                            wslTargetEnvironment.uploadVolumes.forEach { root, volume ->
-                                volume.upload(relativePath ?: "", TargetProgressIndicatorAdapter(indicator))
-                            }
-                        }
-
-                        SyncDirection.UPSTREAM_TO_LOCAL -> {
-                            wslTargetEnvironment.downloadVolumes.forEach { root, volume ->
-                                volume.download(relativePath ?: "", indicator)
-                            }
-                        }
+                        SyncDirection.LOCAL_TO_UPSTREAM -> copyPath(syncPaths.local, syncPaths.upstream, indicator)
+                        SyncDirection.UPSTREAM_TO_LOCAL -> copyPath(syncPaths.upstream, syncPaths.local, indicator)
                     }
-
-                    withContext(Dispatchers.EDT) {
-                        runWriteAction {
-                            VirtualFileManager.getInstance().syncRefresh()
-                        }
-                    }
-
-                }
+                })
             }
 
             override fun onCancel() {}
@@ -155,6 +106,135 @@ fun syncProjectByWslSync(
         },
         ProgressIndicatorBase()
     )
+}
+
+private fun WSLDistribution.toWindowsPath(path: String): String {
+    return if (path.startsWith("/")) getWindowsPath(path) else path
+}
+
+internal data class SyncPaths(val local: NioPath, val upstream: NioPath)
+
+internal fun resolveSyncPaths(
+    localRoot: NioPath,
+    upstreamRoot: NioPath,
+    relativePath: String?
+): SyncPaths {
+    val normalizedLocalRoot = localRoot.normalize()
+    val normalizedUpstreamRoot = upstreamRoot.normalize()
+    val relativeValue = relativePath?.takeIf { it.isNotBlank() }
+    require(relativeValue?.firstOrNull() !in setOf('/', '\\')) {
+        "Sync path must be relative: $relativePath"
+    }
+    val relative = relativeValue
+        ?.let(::Path)
+        ?.normalize()
+
+    require(relative?.isAbsolute != true) { "Sync path must be relative: $relativePath" }
+
+    val local = relative?.let(normalizedLocalRoot::resolve)?.normalize() ?: normalizedLocalRoot
+    val upstream = relative?.let(normalizedUpstreamRoot::resolve)?.normalize() ?: normalizedUpstreamRoot
+    require(local.startsWith(normalizedLocalRoot) && upstream.startsWith(normalizedUpstreamRoot)) {
+        "Sync path escapes its root: $relativePath"
+    }
+    return SyncPaths(local, upstream)
+}
+
+internal fun runSyncWithVfsRefresh(
+    syncAction: () -> Unit,
+    refreshAction: () -> Unit = ::refreshVirtualFileSystem,
+) {
+    try {
+        syncAction()
+    } finally {
+        refreshAction()
+    }
+}
+
+private fun refreshVirtualFileSystem() {
+    invokeLater {
+        runWriteAction {
+            VirtualFileManager.getInstance().syncRefresh()
+        }
+    }
+}
+
+internal fun copyPath(source: NioPath, target: NioPath, indicator: ProgressIndicator) {
+    throwIfCanceled(indicator)
+
+    val sourcePath = source.toAbsolutePath().normalize()
+    if (!Files.exists(sourcePath)) {
+        throw NoSuchFileException(sourcePath.toString())
+    }
+    val targetPath = target.toResolvedPath()
+    val resolvedSource = sourcePath.toRealPath()
+
+    if (resolvedSource == targetPath || Files.exists(targetPath) && Files.isSameFile(resolvedSource, targetPath)) {
+        return
+    }
+
+    if (Files.isDirectory(resolvedSource) && targetPath.startsWith(resolvedSource)) {
+        throw IllegalArgumentException("Sync target cannot be inside the source directory: $targetPath")
+    }
+
+    if (Files.isDirectory(resolvedSource)) {
+        copyDirectoryContents(resolvedSource, targetPath, indicator)
+    } else {
+        copyFile(resolvedSource, targetPath, indicator)
+    }
+}
+
+private fun NioPath.toResolvedPath(): NioPath {
+    val absolutePath = toAbsolutePath().normalize()
+    val missingSegments = ArrayDeque<NioPath>()
+    var existingAncestor = absolutePath
+
+    while (!Files.exists(existingAncestor)) {
+        existingAncestor.fileName?.let(missingSegments::addFirst)
+        existingAncestor = existingAncestor.parent ?: return absolutePath
+    }
+
+    var resolvedPath = existingAncestor.toRealPath()
+    missingSegments.forEach { resolvedPath = resolvedPath.resolve(it.toString()) }
+    return resolvedPath.normalize()
+}
+
+private fun copyDirectoryContents(sourceRoot: NioPath, targetRoot: NioPath, indicator: ProgressIndicator) {
+    Files.createDirectories(targetRoot)
+    Files.walkFileTree(sourceRoot, object : SimpleFileVisitor<NioPath>() {
+        override fun preVisitDirectory(
+            dir: NioPath,
+            attrs: BasicFileAttributes,
+        ): FileVisitResult {
+            throwIfCanceled(indicator)
+            val target = targetRoot.resolve(sourceRoot.relativize(dir).toString())
+            Files.createDirectories(target)
+            return FileVisitResult.CONTINUE
+        }
+
+        override fun visitFile(file: NioPath, attrs: BasicFileAttributes): FileVisitResult {
+            throwIfCanceled(indicator)
+            val target = targetRoot.resolve(sourceRoot.relativize(file).toString())
+            copyFile(file, target, indicator)
+            return FileVisitResult.CONTINUE
+        }
+    })
+}
+
+private fun throwIfCanceled(indicator: ProgressIndicator) {
+    if (indicator.isCanceled) {
+        throw ProcessCanceledException()
+    }
+}
+
+private fun copyFile(source: NioPath, target: NioPath, indicator: ProgressIndicator) {
+    indicator.text2 = source.fileName?.toString() ?: source.toString()
+    target.parent?.let { Files.createDirectories(it) }
+
+    try {
+        Files.copy(source, target, REPLACE_EXISTING, COPY_ATTRIBUTES)
+    } catch (_: UnsupportedOperationException) {
+        Files.copy(source, target, REPLACE_EXISTING)
+    }
 }
 
 private val scope = CoroutineScope(Dispatchers.IO)
@@ -169,20 +249,15 @@ fun transferFolderByToolkit(
 
     when (toolkit.host.type) {
         ToolkitHostType.LOCAL -> {
-            invokeLater {
-                runWriteAction {
-                    VirtualFileManager.getInstance().syncRefresh()
-                }
-            }
+            refreshVirtualFileSystem()
         }
         ToolkitHostType.WSL -> {
             syncProjectByWslSync(
-                scope,
                 project,
                 toolkit.host,
                 direction,
                 directoryPath,
-                relativePath?.let { if (Path(it).isDirectory()) relativePath else null }
+                relativePath
             )
         }
         ToolkitHostType.SSH -> {

--- a/src/main/kotlin/io/xmake/utils/extension/SshToolkitHostExtensionImpl.kt
+++ b/src/main/kotlin/io/xmake/utils/extension/SshToolkitHostExtensionImpl.kt
@@ -25,13 +25,9 @@ import com.intellij.openapi.application.EDT
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.progress.ProgressIndicator
-import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
-import com.intellij.openapi.progress.util.ProgressIndicatorBase
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.guessProjectDir
-import com.intellij.openapi.roots.ProjectRootManager
-import com.intellij.openapi.util.text.Formats
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.ssh.*
 import com.intellij.ssh.config.unified.SshConfig
@@ -82,85 +78,80 @@ class SshToolkitHostExtensionImpl : ToolkitHostExtension {
         host: ToolkitHost,
         direction: SyncDirection,
         remoteDirectory: String,
+        onComplete: () -> Unit,
     ) {
         val sshConfig = (host.target as? SshConfig) ?: throw IllegalArgumentException()
 
-        ProgressManager.getInstance().runProcessWithProgressAsynchronously(
-            object : Task.Backgroundable(project, "Sync directory", true) {
-                override fun run(indicator: ProgressIndicator) {
-                    val commandString = SftpChannelConfig.SftpCommand.detectSftpCommandString
+        object : Task.Backgroundable(project, "Sync directory", true) {
+            override fun run(indicator: ProgressIndicator) {
+                val projectDirectory = project.guessProjectDir()?.path
+                    ?: project.basePath
+                    ?: throw IllegalStateException("Cannot resolve project directory")
+                val projectDirectoryFile = File(projectDirectory)
+                val builder = ConnectionBuilder(sshConfig.host)
+                    .withSshPasswordProvider(PlatformSshPasswordProvider(sshConfig.copyToCredentials()))
 
-                    val builder = ConnectionBuilder(sshConfig.host)
-                        .withSshPasswordProvider(PlatformSshPasswordProvider(sshConfig.copyToCredentials()))
-
-                    val sourceRoots = ProjectRootManager.getInstance(project).contentRoots
-
-                    scope.launch {
-                        val sftpChannel = builder.openFailSafeSftpChannel()
-
+                runBlocking(scope.coroutineContext) {
+                    val sftpChannel = builder.openFailSafeSftpChannel()
+                    try {
                         when (direction) {
                             SyncDirection.LOCAL_TO_UPSTREAM -> {
-
-                                Log.runCatching {
-                                    try {
-                                        sftpChannel.ls(
-                                            remoteDirectory
-                                        )
-                                    } catch (e: SftpChannelNoSuchFileException) {
-                                        Log.warn(e.message)
-                                    }.also { Log.info("before: $it") }
+                                try {
                                     sftpChannel.rmRecur(remoteDirectory)
-                                    Log.info("after: " + sftpChannel.ls("Project"))
+                                } catch (e: SftpChannelNoSuchFileException) {
+                                    Log.debug("Remote sync directory does not exist yet: $remoteDirectory", e)
                                 }
 
                                 sftpChannel.uploadFileOrDir(
-                                    File(project.guessProjectDir()?.path ?: ""),
-                                    remoteDir = remoteDirectory, relativePath = "/",
+                                    projectDirectoryFile,
+                                    remoteDir = remoteDirectory,
+                                    relativePath = "/",
                                     progressTracker = object : SftpProgressTracker {
                                         override val isCanceled: Boolean
-                                            get() = false
-                                        //                TODO("Not yet implemented")
+                                            get() = indicator.isCanceled
 
-                                        override fun onBytesTransferred(count: Long) {
-                                        }
+                                        override fun onBytesTransferred(count: Long) {}
 
-                                        override fun onFileCopied(file: File) {
-                                        }
-                                    }, filesFilter = { file ->
+                                        override fun onFileCopied(file: File) {}
+                                    },
+                                    filesFilter = { file ->
                                         mutableListOf(".xmake", ".idea", "build", ".gitignore")
                                             .all {
                                                 !file.startsWith(
-                                                    Path(
-                                                        project.guessProjectDir()?.path ?: "",
-                                                        it
-                                                    ).toFile()
+                                                    Path(projectDirectory, it).toFile()
                                                 )
                                             }
-                                    }, persistExecutableBit = true
+                                    },
+                                    persistExecutableBit = true,
                                 )
                             }
 
                             SyncDirection.UPSTREAM_TO_LOCAL -> {
-                                sftpChannel.downloadFileOrDir(remoteDirectory, project.guessProjectDir()?.path ?: "")
+                                sftpChannel.downloadFileOrDir(remoteDirectory, projectDirectory)
                             }
                         }
+                    } finally {
                         sftpChannel.close()
+                    }
 
-                        withContext(Dispatchers.EDT) {
-                            runWriteAction {
-                                VirtualFileManager.getInstance().syncRefresh()
-                            }
+                    withContext(Dispatchers.EDT) {
+                        runWriteAction {
+                            VirtualFileManager.getInstance().syncRefresh()
                         }
-
                     }
                 }
+            }
 
-                override fun onCancel() {}
+            override fun onSuccess() {
+                if (!project.isDisposed) {
+                    onComplete()
+                }
+            }
 
-                override fun onFinished() {}
-            },
-            ProgressIndicatorBase()
-        )
+            override fun onThrowable(error: Throwable) {
+                Log.warn("Failed to sync SSH files", error)
+            }
+        }.queue()
     }
 
     override suspend fun ToolkitHost.loadTargetX(project: Project?) = coroutineScope {

--- a/src/main/kotlin/io/xmake/utils/extension/ToolkitHostExtension.kt
+++ b/src/main/kotlin/io/xmake/utils/extension/ToolkitHostExtension.kt
@@ -46,6 +46,7 @@ interface ToolkitHostExtension {
         host: ToolkitHost,
         direction: SyncDirection,
         remoteDirectory: String,
+        onComplete: () -> Unit = {},
     )
 
     fun getTargetId(target: Any? = null): String


### PR DESCRIPTION
**Resolved WSL compatibility and synchronization issues**

## _What Changed_
- Guarded WSL distribution discovery when WSL services are unavailable.
- Replaced target-volume synchronization with direct mapped-path file copies and strict path validation.
- Traversed directory trees with a file visitor while preserving all project content.
- Waited for WSL and SSH transfers to complete before starting generation commands.
- Updated the CMakeLists and compile-commands actions to consume the transfer completion callback before launching generation.
- Preserved cancellation, process-exit, and project-disposal handling across asynchronous callbacks.

## _Why_
- WSL support is optional and must not prevent local or SSH toolkit discovery.
- The previous target-volume integration relied on platform APIs that no longer provide the required compatibility.
- Remote generation could start before project transfer completed, producing incomplete or stale output.

## _Impact_
*WSL synchronization now uses deterministic mapped-path copies and rejects paths outside the intended roots.*
*Generation commands only run after successful project transfer, while local and SSH workflows remain available when WSL cannot be used.*