### PR TITLE
Update IntelliJ Platform build plugins

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,9 +9,9 @@ val localDescription: String = file("${projectDir}/description.html").readText(C
 
 plugins {
     id("java")
-    id("org.jetbrains.intellij.platform") version "2.7.2"
+    id("org.jetbrains.intellij.platform") version "2.18.1"
     id("org.jetbrains.kotlin.jvm") version "2.3.0"
-    id("org.jetbrains.changelog") version "2.2.0"
+    id("org.jetbrains.changelog") version "2.5.0"
     kotlin("plugin.serialization") version "2.3.0"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,7 +65,6 @@ tasks.matching { task -> task.name.contains("buildSearchableOptions") }.configur
 
 dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
-    testImplementation("io.mockk:mockk:1.13.12")
     testImplementation("junit:junit:4.13.2")
 }
 

--- a/clion-debug/build.gradle.kts
+++ b/clion-debug/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     kotlin("jvm") version "2.3.0"
-    id("org.jetbrains.intellij.platform") version "2.7.2"
+    id("org.jetbrains.intellij.platform")
 }
 
 group = "io.xmake.debug"

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,7 @@ pluginSinceBuild=243
 
 runIdeVersion=2025.3
 
+org.jetbrains.intellij.platform.intellijPlatformIdesCacheEnabled=true
+
 org.gradle.warning.mode=all
 kotlin.daemon.jvmargs=-Xmx2048m


### PR DESCRIPTION
**Updated the IntelliJ Platform build plugins and enabled shared IDE caching**

## _What Changed_
- Updated the IntelliJ Platform Gradle Plugin for the root project and the CLion debug module.
- Updated the Gradle Changelog Plugin.
- Enabled the shared IntelliJ IDE cache for all project modules.

## _Why_
- The updated build integration includes current compatibility and caching corrections.
- It includes the upstream IDE-cache behavior correction reported in [intellij-platform-gradle-plugin#2170](https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/2170).
- Reusing extracted IDE installations avoids accumulating redundant copies in Gradle transforms and reduces disk pressure during plugin verification.

## _Impact_
*The root project and CLion debug module now share the project-level IDE cache.*

*This PR changes build tooling only and does not alter the IntelliJ Platform baseline, plugin runtime behavior, or application APIs.*