### PR TITLE
Streamline CI workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,24 +2,23 @@ name: Build
 
 on:
   push:
-    branches: ['**']
+    branches: [dev]
     tags: ['**']
   pull_request:
     branches: ['**']
+  workflow_dispatch:
+
+concurrency:
+  group: build-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          tool-cache: false
-          large-packages: false
-
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Setup Java
         uses: actions/setup-java@v5
@@ -28,7 +27,7 @@ jobs:
           java-version: 21
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build
         run: ./scripts/build.sh


### PR DESCRIPTION
**Reduced redundant CI work while preserving _pull-request_, _post-merge_, and _release_ validation.**

## _What Changed_
- **Automatic triggers:** changed the workflow from every branch push plus every pull request to:
  - pull requests targeting any branch;
  - pushes to `dev`;
  - tag pushes.
- **Manual validation:** added `workflow_dispatch` so maintainers can validate any branch before opening a pull request.
- **Obsolete-run cancellation:** added event-scoped concurrency so a newer update cancels an outdated run of the same pull request, branch, or tag, without allowing different event types to cancel each other.
- **Runner preparation:** removed the unconditional disk-cleanup step.
- **Action maintenance:** updated `actions/checkout` and `gradle/actions/setup-gradle` to their current major versions.
- **Build behavior:** kept the existing `Build` and `Verify Plugin` steps separate and unchanged.

## _Why_
- **Remove duplicate feature-branch CI.** With the previous triggers, pushing a commit to a feature branch with an open pull request started *two complete workflows*: a `push` run for the branch HEAD and a `pull_request` run for the proposed merge result. The pull-request run is the relevant pre-merge check, so running both repeats the same expensive build and plugin verification without providing equivalent integration coverage.
- **Preserve validation at the important boundaries.** Restricting automatic push runs to `dev` and tags removes the duplicate feature-branch run while retaining validation of the *actual post-merge commit* and *release candidates*. Manual dispatch covers branches that need validation before a pull request exists.
- **Cancel only genuinely obsolete work.** When a pull request receives a newer commit, its older pull-request run is no longer useful and can be cancelled. Including the event type in the concurrency key prevents a push check and a pull-request check from cancelling each other or producing an ambiguous required-check result.
- **Remove fixed startup overhead.** The disk-cleanup action removed preinstalled runner content before every build. Repeated workflow runs showed a measurable startup cost without a corresponding storage requirement from this project, so retaining it only delayed the build.
- **Stay on supported Action runtimes.** The Action upgrades include current checkout, cache-correctness, compatibility, and security fixes.
- **Avoid introducing a new memory requirement.** A combined Gradle invocation was evaluated, but it increased the daemon's peak memory usage on the current `dev` baseline. The final workflow therefore keeps the established two-step build and verification sequence and introduces *no JVM memory override*.

## _Impact_

| Scenario | Previous behavior | New behavior |
| --- | --- | --- |
| Feature branch without a pull request | Automatic push CI | **Manual CI when requested** |
| Feature branch with a pull request | Push CI and pull-request CI | **Pull-request CI only** |
| New commit added to an existing pull request | Older runs continued | **Obsolete pull-request run is cancelled** |
| Commit merged to `dev` | Automatic push CI | **Automatic push CI remains** |
| Tag pushed | Automatic tag CI | **Automatic tag CI remains** |

*Fork validation completed successfully with the existing **build**, **plugin verification**, and **artifact upload** behavior intact.*

***This PR changes CI orchestration only.*** *It does not change Gradle project configuration, dependencies, plugin runtime behavior, or application APIs.*

