### PR TITLE
Update IntelliJ Platform compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ You can configure Xmake path, build settings, and Intellisense options in `Setti
 
 ### DAP Debugging (Recommended)
 
-> Only support CLion (>= 2025.3)
+> Only support CLion (>= 2026.1)
 
 XMake now supports native debugging via the Debug Adapter Protocol (DAP). This allows you to debug your XMake targets directly without generating CMakeLists.txt.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,10 @@ repositories {
     }
 }
 
+kotlin {
+    jvmToolchain(21)
+}
+
 intellijPlatform {
     pluginConfiguration {
         version = pluginVersion
@@ -35,8 +39,13 @@ intellijPlatform {
     }
 
     pluginVerification.ides {
-        create(IntelliJPlatformType.CLion, runIdeVersion.get())
-        create(IntelliJPlatformType.IntellijIdeaCommunity, "2024.3")
+        select {
+            types = listOf(
+                IntelliJPlatformType.CLion,
+                IntelliJPlatformType.IntellijIdea
+            )
+            sinceBuild = pluginSinceBuild
+        }
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,9 +10,8 @@ val localDescription = providers.fileContents(layout.projectDirectory.file("desc
 plugins {
     id("java")
     id("org.jetbrains.intellij.platform") version "2.18.1"
-    id("org.jetbrains.kotlin.jvm") version "2.3.0"
+    id("org.jetbrains.kotlin.jvm") version "2.3.20"
     id("org.jetbrains.changelog") version "2.5.0"
-    kotlin("plugin.serialization") version "2.3.0"
 }
 
 group = "io.xmake"
@@ -50,7 +49,6 @@ intellijPlatform {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
     intellijPlatform {
         clion(runIdeVersion)
         bundledPlugin("com.intellij.nativeDebug")

--- a/clion-debug/build.gradle.kts
+++ b/clion-debug/build.gradle.kts
@@ -13,6 +13,10 @@ repositories {
     }
 }
 
+kotlin {
+    jvmToolchain(21)
+}
+
 intellijPlatform {
     // Disable plugin verification and runIDE for the debug module
     pluginVerification {
@@ -22,7 +26,7 @@ intellijPlatform {
 
 dependencies {
     intellijPlatform {
-        clion(providers.gradleProperty("clionDebugApiVersion"))
+        clion(providers.gradleProperty("runIdeVersion"))
         bundledPlugin("com.intellij.nativeDebug")
     }
 }
@@ -38,14 +42,6 @@ tasks.matching { task -> task.name == "verifyPlugin" }.configureEach {
 }
 
 tasks {
-    compileKotlin {
-        compilerOptions.jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
-    }
-
-    compileJava {
-        options.release.set(17)
-    }
-
     jar {
         archiveBaseName.set("xmake-clion-debug")
         archiveVersion.set("")

--- a/clion-debug/build.gradle.kts
+++ b/clion-debug/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "2.3.0"
+    kotlin("jvm") version "2.3.20"
     id("org.jetbrains.intellij.platform")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,6 @@
 pluginVersion=1.4.19
-pluginSinceBuild=243
-
-runIdeVersion=2025.3
-clionDebugApiVersion=2026.1.1
+pluginSinceBuild=261
+runIdeVersion=2026.1.4
 
 org.jetbrains.intellij.platform.intellijPlatformIdesCacheEnabled=true
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,7 @@ pluginSinceBuild=261
 runIdeVersion=2026.1.4
 
 org.jetbrains.intellij.platform.intellijPlatformIdesCacheEnabled=true
+kotlin.stdlib.default.dependency=false
 
 org.gradle.parallel=true
 org.gradle.caching=true

--- a/src/main/kotlin/io/xmake/debug/XMakeDebugSession.kt
+++ b/src/main/kotlin/io/xmake/debug/XMakeDebugSession.kt
@@ -33,7 +33,6 @@ import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.notification.Notifications
 import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.project.Project
 import com.intellij.util.execution.ParametersListUtil
 import com.intellij.xdebugger.XDebugProcess
@@ -50,6 +49,7 @@ import io.xmake.utils.execute.runProcess
 import io.xmake.utils.Logger
 import kotlinx.coroutines.runBlocking
 import java.io.File
+import java.lang.reflect.InvocationTargetException
 
 /**
  * Manages XMake debugging session creation and lifecycle
@@ -189,7 +189,7 @@ class XMakeDebugSession(private val state: RunProfileState, private val environm
      * Create and start the debug session
      */
     private fun createDebugSession(): com.intellij.execution.ui.RunContentDescriptor? {
-        return XDebuggerManager.getInstance(project).startSession(environment, object : XDebugProcessStarter() {
+        val starter = object : XDebugProcessStarter() {
             override fun start(session: XDebugSession): XDebugProcess {
                 val targetName = configuration.runTarget
                 Logger.d(TAG, "Starting debug process for target: $targetName")
@@ -252,7 +252,39 @@ class XMakeDebugSession(private val state: RunProfileState, private val environm
                 
                 return debugProcess
             }
-        }).runContentDescriptor
+        }
+        return startDebugSession(starter)
+    }
+
+    private fun startDebugSession(starter: XDebugProcessStarter): com.intellij.execution.ui.RunContentDescriptor? {
+        try {
+            val manager = XDebuggerManager.getInstance(project)
+            val builder = XDebuggerManager::class.java
+                .getMethod("newSessionBuilder", XDebugProcessStarter::class.java)
+                .invoke(manager, starter)
+            val builderApi = Class.forName(
+                "com.intellij.xdebugger.XDebugSessionBuilder",
+                false,
+                XDebuggerManager::class.java.classLoader
+            )
+            builderApi.getMethod("environment", ExecutionEnvironment::class.java)
+                .invoke(builder, environment)
+            val result = builderApi.getMethod("startSession").invoke(builder)
+            val resultApi = Class.forName(
+                "com.intellij.xdebugger.XSessionStartedResult",
+                false,
+                XDebuggerManager::class.java.classLoader
+            )
+            return resultApi.getMethod("getRunContentDescriptor")
+                .invoke(result) as? com.intellij.execution.ui.RunContentDescriptor
+        } catch (e: InvocationTargetException) {
+            throw e.targetException
+        } catch (e: ReflectiveOperationException) {
+            throw IllegalStateException(
+                "The current IDE does not provide the required debugger session API",
+                e
+            )
+        }
     }
     
     /**
@@ -296,20 +328,6 @@ class XMakeDebugSession(private val state: RunProfileState, private val environm
             )
             .notify(project)
 
-        // Check version compatibility
-        val appInfo = ApplicationInfo.getInstance()
-        val build = appInfo.build
-        // CLion 2025.3 corresponds to baseline version 253
-        if (build.productCode == "CL" && build.baselineVersion < 253) {
-            NotificationGroupManager.getInstance()
-                .getNotificationGroup("XMake.NotificationGroup")
-                .createNotification(
-                    "XMake Debug Support",
-                    "Debugging is only supported in CLion 2025.3 or later. You are using ${appInfo.fullVersion}.",
-                    NotificationType.WARNING
-                )
-                .notify(project)
-        }
     }
     
     /**

--- a/src/main/kotlin/io/xmake/project/wizard/XMakeNewProjectWizardData.kt
+++ b/src/main/kotlin/io/xmake/project/wizard/XMakeNewProjectWizardData.kt
@@ -20,13 +20,20 @@
  */
 package io.xmake.project.wizard
 
-import com.intellij.ide.wizard.NewProjectWizardBaseData
 import com.intellij.ide.wizard.NewProjectWizardStep
 import com.intellij.openapi.observable.properties.GraphProperty
 import com.intellij.openapi.util.Key
 import io.xmake.project.toolkit.Toolkit
 
-interface XMakeNewProjectWizardData : NewProjectWizardBaseData {
+interface XMakeNewProjectWizardData {
+
+    val nameProperty: GraphProperty<String>
+
+    var name: String
+
+    val pathProperty: GraphProperty<String>
+
+    var path: String
 
     val remotePathProperty: GraphProperty<String>
 
@@ -47,7 +54,7 @@ interface XMakeNewProjectWizardData : NewProjectWizardBaseData {
 
     var kind: String
 
-    override val contentEntryPath: String
+    val contentEntryPath: String
         get() = "$path/$name"
 
     companion object {

--- a/src/main/kotlin/io/xmake/run/XMakeRunConfigurationEditor.kt
+++ b/src/main/kotlin/io/xmake/run/XMakeRunConfigurationEditor.kt
@@ -22,8 +22,8 @@ package io.xmake.run
 
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
-import com.intellij.openapi.ui.TextComponentAccessor
-import com.intellij.execution.configuration.EnvironmentVariablesTextFieldWithBrowseButton
+import com.intellij.openapi.ui.TextBrowseFolderListener
+import com.intellij.execution.configuration.EnvironmentVariablesComponent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
@@ -61,6 +61,19 @@ import javax.swing.JComponent
 import javax.swing.JPanel
 import javax.swing.SwingUtilities
 import javax.swing.event.PopupMenuEvent
+
+private fun createEnvironmentVariablesComponent(project: Project): EnvironmentVariablesComponent {
+    // 2026.2 adds the Project constructor and deprecates the 2026.1 no-arg constructor.
+    return try {
+        EnvironmentVariablesComponent::class.java
+            .getConstructor(Project::class.java)
+            .newInstance(project)
+    } catch (_: Exception) {
+        EnvironmentVariablesComponent::class.java
+            .getConstructor()
+            .newInstance()
+    }
+}
 
 class XMakeRunConfigurationEditor(
     private val project: Project,
@@ -108,7 +121,7 @@ class XMakeRunConfigurationEditor(
 
         val selectedArch = architecturesComboBox.item
         architecturesModel.removeAllElements()
-        val currentPlatform = platformsComboBox.item as? String ?: "default"
+        val currentPlatform = platformsComboBox.item ?: "default"
         val architectures = (xmakeInfo.architectures[currentPlatform] ?: emptyList()).plus("default")
         architecturesModel.addAll(architectures)
         architecturesComboBox.item = if (architectures.contains(selectedArch)) selectedArch else runConfiguration.runArchitecture
@@ -186,7 +199,7 @@ class XMakeRunConfigurationEditor(
 
     private val runArguments = RawCommandLineEditor()
 
-    private val environmentVariables = EnvironmentVariablesTextFieldWithBrowseButton()
+    private val environmentVariables = createEnvironmentVariablesComponent(project)
 
     private val workingDirectoryBrowser = DirectoryBrowser(project).apply { text = runConfiguration.runWorkingDir }
 
@@ -233,12 +246,11 @@ class XMakeRunConfigurationEditor(
     private val dapDriverPathComboBox = ComboBox<String>()
     private val dapDriverPathCustomField = TextFieldWithBrowseButton().apply {
         textField.isEditable = true
-        addBrowseFolderListener(
-            "Select DAP Driver",
-            "Select the DAP driver executable (lldb-dap or gdb)",
-            project,
-            FileChooserDescriptorFactory.createSingleFileDescriptor()
-        )
+        val descriptor = FileChooserDescriptorFactory.createSingleFileDescriptor().apply {
+            title = "Select DAP Driver"
+            description = "Select the DAP driver executable (lldb-dap or gdb)"
+        }
+        addBrowseFolderListener(TextBrowseFolderListener(descriptor, project))
     }
 
     // reset editor from configuration
@@ -266,7 +278,7 @@ class XMakeRunConfigurationEditor(
         runArguments.text = configuration.runArguments
 
         // reset environment variables
-        environmentVariables.data = configuration.runEnvironment
+        environmentVariables.envData = configuration.runEnvironment
 
         workingDirectoryBrowser.text = configuration.runWorkingDir
 
@@ -358,7 +370,7 @@ class XMakeRunConfigurationEditor(
 
         configuration.runArguments = runArguments.text
 
-        configuration.runEnvironment = environmentVariables.data
+        configuration.runEnvironment = environmentVariables.envData
 
         configuration.runWorkingDir = workingDirectoryBrowser.text
 
@@ -418,7 +430,7 @@ class XMakeRunConfigurationEditor(
                             val selected = selectedItem
                             if (selected is String) {
                                 val architectures = runConfiguration.getArchitecturesByPlatform(selected)
-                                val currentArch = architecturesComboBox.item as? String
+                                val currentArch = architecturesComboBox.item.orEmpty()
                                 with(architecturesModel) {
                                     removeAllElements()
                                     addAll(architectures.toMutableList())
@@ -495,7 +507,7 @@ class XMakeRunConfigurationEditor(
 
         collapsibleGroup("Additional Configuration") {
             row("Environment variables") {
-                cell(environmentVariables).align(AlignX.FILL)
+                cell(environmentVariables.component).align(AlignX.FILL)
             }
 
             row("Working directory") {

--- a/src/main/kotlin/io/xmake/run/XMakeRunConfigurationEditor.kt
+++ b/src/main/kotlin/io/xmake/run/XMakeRunConfigurationEditor.kt
@@ -246,7 +246,7 @@ class XMakeRunConfigurationEditor(
     private val dapDriverPathComboBox = ComboBox<String>()
     private val dapDriverPathCustomField = TextFieldWithBrowseButton().apply {
         textField.isEditable = true
-        val descriptor = FileChooserDescriptorFactory.createSingleFileDescriptor().apply {
+        val descriptor = FileChooserDescriptorFactory.singleFile().apply {
             title = "Select DAP Driver"
             description = "Select the DAP driver executable (lldb-dap or gdb)"
         }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -104,7 +104,7 @@
                     icon="AllIcons.Actions.ClearCash"
                     description="Clean target and object files."/>
             <separator/>
-            <reference id="editRunConfigurations"/>
+            <reference ref="editRunConfigurations"/>
             <action id="XMake.CleanConfiguration"
                     class="io.xmake.actions.CleanConfigurationAction"
                     text="Clean Configuration"
@@ -132,16 +132,16 @@
         </group>
 
         <group id="XMake.ToolBar" text="Xmake Toolbar" description="XMake toolbar">
-            <reference id="XMake.Run"/>
-            <reference id="XMake.Debug"/>
-            <reference id="XMake.Build"/>
-            <reference id="XMake.Rebuild"/>
-            <reference id="XMake.Clean"/>
+            <reference ref="XMake.Run"/>
+            <reference ref="XMake.Debug"/>
+            <reference ref="XMake.Build"/>
+            <reference ref="XMake.Rebuild"/>
+            <reference ref="XMake.Clean"/>
             <separator/>
-            <reference id="editRunConfigurations"/>
-            <reference id="XMake.CleanConfiguration"/>
+            <reference ref="editRunConfigurations"/>
+            <reference ref="XMake.CleanConfiguration"/>
             <separator/>
-            <reference id="XMake.UpdateCompileCommands"/>
+            <reference ref="XMake.UpdateCompileCommands"/>
         </group>
     </actions>
 


### PR DESCRIPTION
**Updated the plugin baseline and APIs for the current IntelliJ Platform**

## _What Changed_
- Updated the minimum supported platform from the previous compatibility baseline to ***IntelliJ Platform 2026.1***.
- Unified the development IDE, `CLion` debug APIs, `Kotlin` compiler, and `Java` toolchain around the ***same platform generation***.
- Migrated project wizard data, run configuration components, file chooser descriptors, plugin action references, and debugger session creation to the APIs available on the new baseline.
- Removed the separately configured `CLion` debug API version so the main plugin and debug module compile against the ***same IDE version***.
- Reused the `Kotlin` standard library and serialization runtime bundled with the platform instead of packaging additional copies in the plugin.

## _Why_
- ***The previous configuration mixed several API generations.*** The plugin declared an older minimum platform, the development IDE used a newer version, and the `CLion` debug module compiled against a separate API version. Code could therefore compile against one set of APIs while running against another, making the ***debug workflow particularly sensitive to API changes***.

- ***IntelliJ Platform 2026.1 provides a consistent compatibility boundary.*** It is the first supported baseline where the required project, UI, and debugger migrations can be applied consistently across the main plugin and the `CLion`-specific module. Moving the baseline forward also removes compatibility branches for IDE versions that are no longer part of the supported target.

- ***The Kotlin runtime must remain owned by the platform.*** The IDE already bundles its own `Kotlin` standard library and serialization runtime. Aligning the compiler with the bundled version, while avoiding additional `kotlin-stdlib` and `kotlinx-serialization` copies, prevents ***duplicate classes and binary compatibility problems***.

- ***Both modules must use the same Java toolchain.*** The current platform requires `Java 21` for plugin development, so the main plugin and the `CLion` debug module now compile against the same toolchain.

- ***`EnvironmentVariablesComponent` is transitioning between platform releases.*** IntelliJ Platform 2026.1 provides the no-argument constructor, while 2026.2 introduces the project-aware constructor and deprecates the previous one. A small reflection bridge prefers the new constructor when available and falls back to the 2026.1 constructor without statically linking the plugin to either version-specific call.

- ***The debugger session replacement is not yet a stable static API.*** The previous `XDebuggerManager.startSession` API is deprecated on the 2026.1 baseline, while the replacement `XDebugSessionBuilder` and `XSessionStartedResult` interfaces are still marked *experimental*. Calling them directly causes `Plugin Verifier` failures. The reflection bridge invokes the required builder workflow without recording a static dependency on those experimental interfaces, while preserving the same `ExecutionEnvironment` and `RunContentDescriptor`.

## _Impact_
***The main plugin and CLion debug integration now compile and run against one consistent IntelliJ Platform baseline.***

*Project creation, run configuration editing, and debugging retain their existing user-facing behavior, while version-specific compatibility logic remains limited to the two API transitions described above.*
