### PR TITLE
Initialize the XMake console before GUI actions

### DIFF
--- a/src/main/kotlin/io/xmake/actions/BuildAction.kt
+++ b/src/main/kotlin/io/xmake/actions/BuildAction.kt
@@ -26,46 +26,42 @@ import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
-import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.actionSystem.AnActionEvent
-import io.xmake.project.xmakeConsoleView
+import io.xmake.project.console.XMakeConsole
 import io.xmake.shared.xmakeConfiguration
 import io.xmake.utils.SystemUtils
 import io.xmake.utils.exception.XMakeRunConfigurationNotSetException
 import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.project.Project
 import io.xmake.project.xmakeSettings
 
-class BuildAction : XMakeBaseAction() {
+class BuildAction : XMakeConsoleAction() {
 
-    override fun actionPerformed(e: AnActionEvent) {
-
-        // the project
-        val project = e.project ?: return
+    override fun execute(project: Project, console: XMakeConsole) {
 
         // save all files
         FileDocumentManager.getInstance().saveAllDocuments()
 
         // clear console first
-        project.xmakeConsoleView.clear()
+        console.clear()
 
         try {
             // configure and build it
             val xmakeConfiguration = project.xmakeConfiguration
             if (xmakeConfiguration.changed) {
-                SystemUtils.runvInConsole(project, xmakeConfiguration.configurationCommandLine)
+                SystemUtils.runvInConsole(project, console, xmakeConfiguration.configurationCommandLine)
                     ?.addProcessListener(object : ProcessListener {
                         override fun processTerminated(e: ProcessEvent) {
                             if (e.exitCode == 0) {
-                                runBuild(project, xmakeConfiguration)
+                                runBuild(project, console, xmakeConfiguration)
                             }
                         }
                     })
                 xmakeConfiguration.changed = false
             } else {
-                runBuild(project, xmakeConfiguration)
+                runBuild(project, console, xmakeConfiguration)
             }
         } catch (e: XMakeRunConfigurationNotSetException) {
-            project.xmakeConsoleView.print(
+            console.print(
                 "Please select a xmake run configuration first!\n",
                 ConsoleViewContentType.ERROR_OUTPUT
             )
@@ -74,7 +70,7 @@ class BuildAction : XMakeBaseAction() {
                 .createNotification("Error with XMake Configuration", e.message ?: "", NotificationType.ERROR)
                 .notify(project)
         } catch (e: ExecutionException) {
-            project.xmakeConsoleView.print(
+            console.print(
                 "An error occurred during build: ${e.message}\n",
                 ConsoleViewContentType.ERROR_OUTPUT
             )
@@ -85,12 +81,12 @@ class BuildAction : XMakeBaseAction() {
         }
     }
 
-    private fun runBuild(project: com.intellij.openapi.project.Project, xmakeConfiguration: io.xmake.shared.XMakeConfiguration) {
-        SystemUtils.runvInConsole(project, xmakeConfiguration.buildCommandLine, true, true, true)
+    private fun runBuild(project: Project, console: XMakeConsole, xmakeConfiguration: io.xmake.shared.XMakeConfiguration) {
+        SystemUtils.runvInConsole(project, console, xmakeConfiguration.buildCommandLine, true, true, true)
             ?.addProcessListener(object : ProcessListener {
                 override fun processTerminated(e: ProcessEvent) {
                     if (e.exitCode == 0 && project.xmakeSettings.state.autoUpdateCompileCommands) {
-                        SystemUtils.runvInConsole(project, xmakeConfiguration.updateCompileCommandsLine, false, true, true)
+                        SystemUtils.runvInConsole(project, console, xmakeConfiguration.updateCompileCommandsLine, false, true, true)
                     }
                 }
             })

--- a/src/main/kotlin/io/xmake/actions/CleanAction.kt
+++ b/src/main/kotlin/io/xmake/actions/CleanAction.kt
@@ -25,39 +25,35 @@ import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
-import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.actionSystem.AnActionEvent
-import io.xmake.project.xmakeConsoleView
+import com.intellij.openapi.project.Project
+import io.xmake.project.console.XMakeConsole
 import io.xmake.shared.xmakeConfiguration
 import io.xmake.utils.SystemUtils
 import io.xmake.utils.exception.XMakeRunConfigurationNotSetException
 
-class CleanAction : XMakeBaseAction() {
+class CleanAction : XMakeConsoleAction() {
 
-    override fun actionPerformed(e: AnActionEvent) {
-
-        // the project
-        val project = e.project ?: return
+    override fun execute(project: Project, console: XMakeConsole) {
 
         // clear console first
-        project.xmakeConsoleView.clear()
+        console.clear()
 
         try {
             // configure and clean it
             val xmakeConfiguration = project.xmakeConfiguration
             if (xmakeConfiguration.changed) {
-                SystemUtils.runvInConsole(project, xmakeConfiguration.configurationCommandLine)
+                SystemUtils.runvInConsole(project, console, xmakeConfiguration.configurationCommandLine)
                     ?.addProcessListener(object : ProcessListener {
                         override fun processTerminated(e: ProcessEvent) {
-                            SystemUtils.runvInConsole(project, xmakeConfiguration.cleanCommandLine, false, false, true)
+                            SystemUtils.runvInConsole(project, console, xmakeConfiguration.cleanCommandLine, false, false, true)
                         }
                     })
                 xmakeConfiguration.changed = false
             } else {
-                SystemUtils.runvInConsole(project, xmakeConfiguration.cleanCommandLine, true, false, true)
+                SystemUtils.runvInConsole(project, console, xmakeConfiguration.cleanCommandLine, true, false, true)
             }
         } catch (e: XMakeRunConfigurationNotSetException) {
-            project.xmakeConsoleView.print(
+            console.print(
                 "Please select a xmake run configuration first!\n",
                 ConsoleViewContentType.ERROR_OUTPUT
             )

--- a/src/main/kotlin/io/xmake/actions/CleanConfigurationAction.kt
+++ b/src/main/kotlin/io/xmake/actions/CleanConfigurationAction.kt
@@ -23,30 +23,26 @@ package io.xmake.actions
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
-import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.actionSystem.AnActionEvent
-import io.xmake.project.xmakeConsoleView
+import com.intellij.openapi.project.Project
+import io.xmake.project.console.XMakeConsole
 import io.xmake.shared.xmakeConfiguration
 import io.xmake.utils.SystemUtils
 import io.xmake.utils.exception.XMakeRunConfigurationNotSetException
 
-class CleanConfigurationAction : XMakeBaseAction() {
+class CleanConfigurationAction : XMakeConsoleAction() {
 
-    override fun actionPerformed(e: AnActionEvent) {
-
-        // the project
-        val project = e.project ?: return
+    override fun execute(project: Project, console: XMakeConsole) {
 
         // clear console first
-        project.xmakeConsoleView.clear()
+        console.clear()
 
         try {
             // clear configure
             val xmakeConfiguration = project.xmakeConfiguration
-            SystemUtils.runvInConsole(project, xmakeConfiguration.cleanConfigurationCommandLine, true, false, true)
+            SystemUtils.runvInConsole(project, console, xmakeConfiguration.cleanConfigurationCommandLine, true, false, true)
             xmakeConfiguration.changed = false
         } catch (e: XMakeRunConfigurationNotSetException) {
-            project.xmakeConsoleView.print(
+            console.print(
                 "Please select a xmake run configuration first!\n",
                 ConsoleViewContentType.ERROR_OUTPUT
             )

--- a/src/main/kotlin/io/xmake/actions/DebugAction.kt
+++ b/src/main/kotlin/io/xmake/actions/DebugAction.kt
@@ -6,11 +6,12 @@ import com.intellij.execution.executors.DefaultDebugExecutor
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.Project
 import io.xmake.run.XMakeRunConfiguration
 import io.xmake.run.XMakeRunner
 import io.xmake.utils.SystemUtils
 
-class DebugAction : XMakeBaseAction() {
+class DebugAction : XMakeProjectAction() {
 
     override fun update(e: AnActionEvent) {
         super.update(e)
@@ -24,8 +25,7 @@ class DebugAction : XMakeBaseAction() {
         }
     }
 
-    override fun actionPerformed(e: AnActionEvent) {
-        val project = e.project ?: return
+    override fun execute(project: Project) {
         val runManager = RunManager.getInstance(project)
         val selectedSettings = runManager.selectedConfiguration
 

--- a/src/main/kotlin/io/xmake/actions/QuickStartAction.kt
+++ b/src/main/kotlin/io/xmake/actions/QuickStartAction.kt
@@ -82,7 +82,9 @@ class QuickStartAction : XMakeProjectAction() {
                                 }
 
                                 // Show Tool Window
-                                project.xmakeConsoleService.currentConsole.showOutput()
+                                project.xmakeConsoleService.whenReady { console ->
+                                    console.showOutput()
+                                }
                             }
                         } else {
                             NotificationGroupManager.getInstance()
@@ -102,7 +104,7 @@ class QuickStartAction : XMakeProjectAction() {
             return
         }
 
-        project.xmakeConsoleService.currentConsole.let { console ->
+        project.xmakeConsoleService.whenReady { console ->
             // clear console first
             console.clear()
 

--- a/src/main/kotlin/io/xmake/actions/QuickStartAction.kt
+++ b/src/main/kotlin/io/xmake/actions/QuickStartAction.kt
@@ -27,20 +27,19 @@ import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
-import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.wm.ToolWindowManager
 import io.xmake.project.toolkit.activatedToolkit
-import io.xmake.project.xmakeConsoleView
+import io.xmake.project.console.xmakeConsoleService
 import io.xmake.shared.xmakeConfiguration
 import io.xmake.utils.SystemUtils
 import io.xmake.utils.exception.XMakeRunConfigurationNotSetException
 import java.io.File
 
-class QuickStartAction : AnAction() {
+class QuickStartAction : XMakeProjectAction() {
 
     override fun update(e: AnActionEvent) {
         val project = e.project
@@ -52,10 +51,7 @@ class QuickStartAction : AnAction() {
         e.presentation.isEnabled = !SystemUtils.isXMakeProject(project)
     }
 
-    override fun actionPerformed(e: AnActionEvent) {
-
-        // the project
-        val project = e.project ?: return
+    override fun execute(project: Project) {
 
         if (!SystemUtils.isXMakeProject(project)) {
             val xmakePath = project.activatedToolkit?.path ?: "xmake"
@@ -74,7 +70,7 @@ class QuickStartAction : AnAction() {
                                 .createNotification("XMake project created successfully!", NotificationType.INFORMATION)
                                 .notify(project)
 
-                            ApplicationManager.getApplication().invokeLater {
+                            ToolWindowManager.getInstance(project).invokeLater {
                                 if (project.isDisposed) return@invokeLater
 
                                 // Refresh VFS
@@ -86,9 +82,7 @@ class QuickStartAction : AnAction() {
                                 }
 
                                 // Show Tool Window
-                                ToolWindowManager.getInstance(project)
-                                    .getToolWindow("XMake")
-                                    ?.show(null)
+                                project.xmakeConsoleService.currentConsole.showOutput()
                             }
                         } else {
                             NotificationGroupManager.getInstance()
@@ -108,21 +102,23 @@ class QuickStartAction : AnAction() {
             return
         }
 
-        // clear console first
-        project.xmakeConsoleView.clear()
+        project.xmakeConsoleService.currentConsole.let { console ->
+            // clear console first
+            console.clear()
 
-        try {
-            // quick start
-            SystemUtils.runvInConsole(project, project.xmakeConfiguration.quickStartCommandLine, true, false, true)
-        } catch (e: XMakeRunConfigurationNotSetException) {
-            project.xmakeConsoleView.print(
-                "Please select a xmake run configuration first!\n",
-                ConsoleViewContentType.ERROR_OUTPUT
-            )
-            NotificationGroupManager.getInstance()
-                .getNotificationGroup("XMake.NotificationGroup")
-                .createNotification("Error with XMake Configuration", e.message ?: "", NotificationType.ERROR)
-                .notify(project)
+            try {
+                // quick start
+                SystemUtils.runvInConsole(project, console, project.xmakeConfiguration.quickStartCommandLine, true, false, true)
+            } catch (e: XMakeRunConfigurationNotSetException) {
+                console.print(
+                    "Please select a xmake run configuration first!\n",
+                    ConsoleViewContentType.ERROR_OUTPUT
+                )
+                NotificationGroupManager.getInstance()
+                    .getNotificationGroup("XMake.NotificationGroup")
+                    .createNotification("Error with XMake Configuration", e.message ?: "", NotificationType.ERROR)
+                    .notify(project)
+            }
         }
 
     }

--- a/src/main/kotlin/io/xmake/actions/RebuildAction.kt
+++ b/src/main/kotlin/io/xmake/actions/RebuildAction.kt
@@ -26,39 +26,35 @@ import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
-import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.actionSystem.AnActionEvent
-import io.xmake.project.xmakeConsoleView
+import com.intellij.openapi.project.Project
+import io.xmake.project.console.XMakeConsole
 import io.xmake.shared.xmakeConfiguration
 import io.xmake.utils.SystemUtils
 import io.xmake.utils.exception.XMakeRunConfigurationNotSetException
 
-class RebuildAction : XMakeBaseAction() {
+class RebuildAction : XMakeConsoleAction() {
 
-    override fun actionPerformed(e: AnActionEvent) {
-
-        // the project
-        val project = e.project ?: return
+    override fun execute(project: Project, console: XMakeConsole) {
 
         // clear console first
-        project.xmakeConsoleView.clear()
+        console.clear()
 
         try {
             // configure and rebuild it
             val xmakeConfiguration = project.xmakeConfiguration
             if (xmakeConfiguration.changed) {
-                SystemUtils.runvInConsole(project, xmakeConfiguration.configurationCommandLine)
+                SystemUtils.runvInConsole(project, console, xmakeConfiguration.configurationCommandLine)
                     ?.addProcessListener(object : ProcessListener {
                         override fun processTerminated(e: ProcessEvent) {
-                            SystemUtils.runvInConsole(project, xmakeConfiguration.rebuildCommandLine, false, true, true)
+                            SystemUtils.runvInConsole(project, console, xmakeConfiguration.rebuildCommandLine, false, true, true)
                         }
                     })
                 xmakeConfiguration.changed = false
             } else {
-                SystemUtils.runvInConsole(project, xmakeConfiguration.rebuildCommandLine, true, true, true)
+                SystemUtils.runvInConsole(project, console, xmakeConfiguration.rebuildCommandLine, true, true, true)
             }
         } catch (e: XMakeRunConfigurationNotSetException) {
-            project.xmakeConsoleView.print(
+            console.print(
                 "Please select a xmake run configuration first!\n",
                 ConsoleViewContentType.ERROR_OUTPUT
             )
@@ -67,7 +63,7 @@ class RebuildAction : XMakeBaseAction() {
                 .createNotification("Error with XMake Configuration", e.message ?: "", NotificationType.ERROR)
                 .notify(project)
         } catch (e: ExecutionException) {
-            project.xmakeConsoleView.print(
+            console.print(
                 "An error occurred during rebuild: ${e.message}\n",
                 ConsoleViewContentType.ERROR_OUTPUT
             )

--- a/src/main/kotlin/io/xmake/actions/RunAction.kt
+++ b/src/main/kotlin/io/xmake/actions/RunAction.kt
@@ -25,36 +25,33 @@ import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
-import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.actionSystem.AnActionEvent
-import io.xmake.project.xmakeConsoleView
+import io.xmake.project.console.XMakeConsole
 import io.xmake.shared.xmakeConfiguration
 import io.xmake.utils.SystemUtils
 import io.xmake.utils.exception.XMakeRunConfigurationNotSetException
 import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.project.Project
 
-class RunAction : XMakeBaseAction() {
+class RunAction : XMakeConsoleAction() {
 
-    override fun actionPerformed(e: AnActionEvent) {
-
-        // the project
-        val project = e.project ?: return
+    override fun execute(project: Project, console: XMakeConsole) {
 
         // save all files
         FileDocumentManager.getInstance().saveAllDocuments()
 
         // clear console first
-        project.xmakeConsoleView.clear()
+        console.clear()
 
         try {
             // configure and run it
             val xmakeConfiguration = project.xmakeConfiguration
             if (xmakeConfiguration.changed) {
-                SystemUtils.runvInConsole(project, xmakeConfiguration.configurationCommandLine)
+                SystemUtils.runvInConsole(project, console, xmakeConfiguration.configurationCommandLine)
                     ?.addProcessListener(object : ProcessListener {
                         override fun processTerminated(e: ProcessEvent) {
                             SystemUtils.runvInConsole(
                                 project,
+                                console,
                                 xmakeConfiguration.configuration.runCommandLine,
                                 false,
                                 true,
@@ -64,11 +61,11 @@ class RunAction : XMakeBaseAction() {
                     })
                 xmakeConfiguration.changed = false
             } else {
-                SystemUtils.runvInConsole(project, xmakeConfiguration.configuration.runCommandLine, true, true, true)
+                SystemUtils.runvInConsole(project, console, xmakeConfiguration.configuration.runCommandLine, true, true, true)
             }
 
         } catch (e: XMakeRunConfigurationNotSetException) {
-            project.xmakeConsoleView.print(
+            console.print(
                 "Please select a xmake run configuration first!\n",
                 ConsoleViewContentType.ERROR_OUTPUT
             )

--- a/src/main/kotlin/io/xmake/actions/UpdateCmakeListsAction.kt
+++ b/src/main/kotlin/io/xmake/actions/UpdateCmakeListsAction.kt
@@ -25,22 +25,20 @@ import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
-import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.Project
 import io.xmake.project.toolkit.activatedToolkit
-import io.xmake.project.xmakeConsoleView
+import io.xmake.project.console.XMakeConsole
 import io.xmake.shared.xmakeConfiguration
 import io.xmake.utils.SystemUtils
 import io.xmake.utils.exception.XMakeRunConfigurationNotSetException
 import io.xmake.utils.execute.fetchGeneratedFile
 import io.xmake.utils.execute.syncBeforeFetch
 
-class UpdateCmakeListsAction : XMakeBaseAction() {
-    override fun actionPerformed(e: AnActionEvent) {
-        // the project
-        val project = e.project ?: return
+class UpdateCmakeListsAction : XMakeConsoleAction() {
+    override fun execute(project: Project, console: XMakeConsole) {
 
         // clear console first
-        project.xmakeConsoleView.clear()
+        console.clear()
 
         try {
             // configure and build it
@@ -54,6 +52,7 @@ class UpdateCmakeListsAction : XMakeBaseAction() {
 
                     SystemUtils.runvInConsole(
                         project,
+                        console,
                         xmakeConfiguration.updateCmakeListsCommandLine,
                         false,
                         true,
@@ -70,7 +69,7 @@ class UpdateCmakeListsAction : XMakeBaseAction() {
             }
 
             if (xmakeConfiguration.changed) {
-                SystemUtils.runvInConsole(project, xmakeConfiguration.configurationCommandLine)
+                SystemUtils.runvInConsole(project, console, xmakeConfiguration.configurationCommandLine)
                     ?.addProcessListener(object : ProcessListener {
                         override fun processTerminated(event: ProcessEvent) {
                             if (project.isDisposed || event.exitCode != 0) return
@@ -82,7 +81,7 @@ class UpdateCmakeListsAction : XMakeBaseAction() {
                 updateCmakeLists()
             }
         } catch (e: XMakeRunConfigurationNotSetException) {
-            project.xmakeConsoleView.print(
+            console.print(
                 "Please select a xmake run configuration first!\n",
                 ConsoleViewContentType.ERROR_OUTPUT
             )

--- a/src/main/kotlin/io/xmake/actions/UpdateCompileCommandsAction.kt
+++ b/src/main/kotlin/io/xmake/actions/UpdateCompileCommandsAction.kt
@@ -26,25 +26,23 @@ import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
-import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFileManager
 import io.xmake.project.toolkit.activatedToolkit
-import io.xmake.project.xmakeConsoleView
+import io.xmake.project.console.XMakeConsole
 import io.xmake.shared.xmakeConfiguration
 import io.xmake.utils.SystemUtils
 import io.xmake.utils.exception.XMakeRunConfigurationNotSetException
 import io.xmake.utils.execute.fetchGeneratedFile
 import io.xmake.utils.execute.syncBeforeFetch
 
-class UpdateCompileCommandsAction : XMakeBaseAction() {
-    override fun actionPerformed(e: AnActionEvent) {
-        // the project
-        val project = e.project ?: return
+class UpdateCompileCommandsAction : XMakeConsoleAction() {
+    override fun execute(project: Project, console: XMakeConsole) {
 
         // clear console first
-        project.xmakeConsoleView.clear()
+        console.clear()
 
         try {
             // configure and build it
@@ -58,6 +56,7 @@ class UpdateCompileCommandsAction : XMakeBaseAction() {
 
                     SystemUtils.runvInConsole(
                         project,
+                        console,
                         xmakeConfiguration.updateCompileCommandsLine,
                         false,
                         true,
@@ -90,7 +89,7 @@ class UpdateCompileCommandsAction : XMakeBaseAction() {
             }
 
             if (xmakeConfiguration.changed) {
-                SystemUtils.runvInConsole(project, xmakeConfiguration.configurationCommandLine)
+                SystemUtils.runvInConsole(project, console, xmakeConfiguration.configurationCommandLine)
                     ?.addProcessListener(object : ProcessListener {
                         override fun processTerminated(event: ProcessEvent) {
                             if (project.isDisposed || event.exitCode != 0) return
@@ -102,7 +101,7 @@ class UpdateCompileCommandsAction : XMakeBaseAction() {
                 updateCompileCommands()
             }
         } catch (e: XMakeRunConfigurationNotSetException) {
-            project.xmakeConsoleView.print(
+            console.print(
                 "Please select a xmake run configuration first!\n",
                 ConsoleViewContentType.ERROR_OUTPUT
             )
@@ -111,7 +110,7 @@ class UpdateCompileCommandsAction : XMakeBaseAction() {
                 .createNotification("Error with XMake Configuration", e.message ?: "", NotificationType.ERROR)
                 .notify(project)
         } catch (e: ExecutionException) {
-            project.xmakeConsoleView.print(
+            console.print(
                 "An error occurred during update: ${e.message}\n",
                 ConsoleViewContentType.ERROR_OUTPUT
             )

--- a/src/main/kotlin/io/xmake/actions/XMakeConsoleAction.kt
+++ b/src/main/kotlin/io/xmake/actions/XMakeConsoleAction.kt
@@ -1,0 +1,14 @@
+package io.xmake.actions
+
+import com.intellij.openapi.project.Project
+import io.xmake.project.console.XMakeConsole
+import io.xmake.project.console.xmakeConsoleService
+
+abstract class XMakeConsoleAction : XMakeProjectAction() {
+
+    final override fun execute(project: Project) {
+        execute(project, project.xmakeConsoleService.currentConsole)
+    }
+
+    protected abstract fun execute(project: Project, console: XMakeConsole)
+}

--- a/src/main/kotlin/io/xmake/actions/XMakeConsoleAction.kt
+++ b/src/main/kotlin/io/xmake/actions/XMakeConsoleAction.kt
@@ -7,7 +7,9 @@ import io.xmake.project.console.xmakeConsoleService
 abstract class XMakeConsoleAction : XMakeProjectAction() {
 
     final override fun execute(project: Project) {
-        execute(project, project.xmakeConsoleService.currentConsole)
+        project.xmakeConsoleService.whenReady { console ->
+            execute(project, console)
+        }
     }
 
     protected abstract fun execute(project: Project, console: XMakeConsole)

--- a/src/main/kotlin/io/xmake/actions/XMakeProjectAction.kt
+++ b/src/main/kotlin/io/xmake/actions/XMakeProjectAction.kt
@@ -2,9 +2,17 @@ package io.xmake.actions
 
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.Project
 import io.xmake.utils.SystemUtils
 
-abstract class XMakeBaseAction : AnAction() {
+abstract class XMakeProjectAction : AnAction() {
+
+    final override fun actionPerformed(event: AnActionEvent) {
+        val project = event.project ?: return
+        execute(project)
+    }
+
+    protected abstract fun execute(project: Project)
 
     override fun update(e: AnActionEvent) {
         val project = e.project

--- a/src/main/kotlin/io/xmake/debug/XMakeDebugSession.kt
+++ b/src/main/kotlin/io/xmake/debug/XMakeDebugSession.kt
@@ -41,10 +41,10 @@ import com.intellij.xdebugger.XDebugSession
 import com.intellij.xdebugger.XDebuggerManager
 import io.xmake.run.XMakeRunConfiguration
 import io.xmake.shared.xmakeConfiguration
+import io.xmake.project.console.XMakeConsole
 import io.xmake.project.toolkit.activatedToolkit
 import io.xmake.utils.SystemUtils
 import io.xmake.debug.DebugModuleLoader
-import io.xmake.project.xmakeConsoleView
 import io.xmake.utils.execute.runProcess
 import io.xmake.utils.Logger
 import kotlinx.coroutines.runBlocking
@@ -54,7 +54,11 @@ import java.lang.reflect.InvocationTargetException
 /**
  * Manages XMake debugging session creation and lifecycle
  */
-class XMakeDebugSession(private val state: RunProfileState, private val environment: ExecutionEnvironment) {
+class XMakeDebugSession(
+    private val state: RunProfileState,
+    private val environment: ExecutionEnvironment,
+    private val console: XMakeConsole
+) {
     
     private val project: Project = environment.project
     private val configuration: XMakeRunConfiguration = environment.runProfile as XMakeRunConfiguration
@@ -92,10 +96,10 @@ class XMakeDebugSession(private val state: RunProfileState, private val environm
     private fun buildProject() {
         Logger.d(TAG, "Building project before debug...")
         val xmakeConfiguration = project.xmakeConfiguration
-        project.xmakeConsoleView.clear()
+        console.clear()
 
         if (xmakeConfiguration.changed) {
-            val configProcess = SystemUtils.runvInConsole(project, xmakeConfiguration.configurationCommandLine)
+            val configProcess = SystemUtils.runvInConsole(project, console, xmakeConfiguration.configurationCommandLine)
             configProcess?.waitFor()
             xmakeConfiguration.changed = false
         }
@@ -105,7 +109,7 @@ class XMakeDebugSession(private val state: RunProfileState, private val environm
             EnvironmentVariablesData.DEFAULT
         ).withWorkDirectory(project.basePath)
 
-        val buildProcess = SystemUtils.runvInConsole(project, buildCommandLine, false, true, false)
+        val buildProcess = SystemUtils.runvInConsole(project, console, buildCommandLine, false, true, false)
         buildProcess?.waitFor()
         Logger.d(TAG, "Build completed")
     }

--- a/src/main/kotlin/io/xmake/project/console/XMakeConsoleService.kt
+++ b/src/main/kotlin/io/xmake/project/console/XMakeConsoleService.kt
@@ -4,11 +4,14 @@ import com.intellij.execution.ui.ConsoleView
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.ui.content.Content
 import io.xmake.shared.XMakeProblem
+
+private val Log = logger<XMakeConsoleService>()
 
 class XMakeConsole internal constructor(
     private val project: Project,
@@ -29,6 +32,8 @@ class XMakeConsole internal constructor(
     }
 
     fun showOutput() {
+        if (project.isDisposed) return
+
         ToolWindowManager.getInstance(project).invokeLater {
             if (project.isDisposed) return@invokeLater
 
@@ -41,6 +46,8 @@ class XMakeConsole internal constructor(
     }
 
     fun updateProblems(problems: List<XMakeProblem>) {
+        if (project.isDisposed) return
+
         ToolWindowManager.getInstance(project).invokeLater {
             if (!project.isDisposed) {
                 problemPanel.problems = problems
@@ -53,9 +60,6 @@ class XMakeConsole internal constructor(
 class XMakeConsoleService(private val project: Project) {
     private var console: XMakeConsole? = null
 
-    val currentConsole: XMakeConsole
-        get() = checkNotNull(console) { "XMake console has not been initialized" }
-
     internal fun register(
         toolWindow: ToolWindow,
         outputPanel: XMakeToolWindowOutputPanel,
@@ -66,6 +70,58 @@ class XMakeConsoleService(private val project: Project) {
         console = XMakeConsole(project, toolWindow, outputPanel, problemPanel, outputContent)
     }
 
+    fun whenReady(
+        onUnavailable: (Throwable) -> Unit = { Log.warn("XMake console is unavailable", it) },
+        action: (XMakeConsole) -> Unit
+    ) {
+        val application = ApplicationManager.getApplication()
+        if (application.isDispatchThread) {
+            runWhenReady(onUnavailable, action)
+            return
+        }
+
+        if (project.isDisposed) {
+            onUnavailable(IllegalStateException("Project was disposed before the XMake console was initialized"))
+            return
+        }
+
+        val toolWindowManager = ToolWindowManager.getInstance(project)
+        toolWindowManager.invokeLater {
+            runWhenReady(onUnavailable, action)
+        }
+    }
+
+    private fun runWhenReady(
+        onUnavailable: (Throwable) -> Unit,
+        action: (XMakeConsole) -> Unit
+    ) {
+        check(ApplicationManager.getApplication().isDispatchThread)
+
+        if (project.isDisposed) {
+            onUnavailable(IllegalStateException("Project was disposed before the XMake console was initialized"))
+            return
+        }
+
+        console?.let {
+            action(it)
+            return
+        }
+
+        val toolWindow = ToolWindowManager.getInstance(project).getToolWindow(XMAKE_TOOL_WINDOW_ID)
+        if (toolWindow == null) {
+            onUnavailable(IllegalStateException("XMake tool window is not registered"))
+            return
+        }
+
+        // Accessing the content manager initializes descriptor-owned tool window content.
+        toolWindow.contentManager
+        val initializedConsole = console
+        if (initializedConsole == null) {
+            onUnavailable(IllegalStateException("XMake console was not initialized"))
+            return
+        }
+        action(initializedConsole)
+    }
 }
 
 val Project.xmakeConsoleService: XMakeConsoleService

--- a/src/main/kotlin/io/xmake/project/console/XMakeConsoleService.kt
+++ b/src/main/kotlin/io/xmake/project/console/XMakeConsoleService.kt
@@ -1,0 +1,72 @@
+package io.xmake.project.console
+
+import com.intellij.execution.ui.ConsoleView
+import com.intellij.execution.ui.ConsoleViewContentType
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.ui.content.Content
+import io.xmake.shared.XMakeProblem
+
+class XMakeConsole internal constructor(
+    private val project: Project,
+    private val toolWindow: ToolWindow,
+    private val outputPanel: XMakeToolWindowOutputPanel,
+    private val problemPanel: XMakeToolWindowProblemPanel,
+    private val outputContent: Content
+) {
+    internal val view: ConsoleView
+        get() = outputPanel.consoleView
+
+    fun clear() {
+        view.clear()
+    }
+
+    fun print(text: String, contentType: ConsoleViewContentType) {
+        view.print(text, contentType)
+    }
+
+    fun showOutput() {
+        ToolWindowManager.getInstance(project).invokeLater {
+            if (project.isDisposed) return@invokeLater
+
+            toolWindow.show {
+                if (!project.isDisposed) {
+                    toolWindow.contentManager.setSelectedContent(outputContent)
+                }
+            }
+        }
+    }
+
+    fun updateProblems(problems: List<XMakeProblem>) {
+        ToolWindowManager.getInstance(project).invokeLater {
+            if (!project.isDisposed) {
+                problemPanel.problems = problems
+            }
+        }
+    }
+}
+
+@Service(Service.Level.PROJECT)
+class XMakeConsoleService(private val project: Project) {
+    private var console: XMakeConsole? = null
+
+    val currentConsole: XMakeConsole
+        get() = checkNotNull(console) { "XMake console has not been initialized" }
+
+    internal fun register(
+        toolWindow: ToolWindow,
+        outputPanel: XMakeToolWindowOutputPanel,
+        problemPanel: XMakeToolWindowProblemPanel,
+        outputContent: Content
+    ) {
+        check(ApplicationManager.getApplication().isDispatchThread)
+        console = XMakeConsole(project, toolWindow, outputPanel, problemPanel, outputContent)
+    }
+
+}
+
+val Project.xmakeConsoleService: XMakeConsoleService
+    get() = getService(XMakeConsoleService::class.java)

--- a/src/main/kotlin/io/xmake/project/console/XMakeToolWindowFactory.kt
+++ b/src/main/kotlin/io/xmake/project/console/XMakeToolWindowFactory.kt
@@ -18,16 +18,13 @@
  * @file        XMakeToolWindowFactory.kt
  *
  */
-package io.xmake.project
+package io.xmake.project.console
 
-import com.intellij.execution.ui.ConsoleView
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
-import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.ui.content.ContentFactory
-import io.xmake.shared.XMakeProblem
 import kotlin.jvm.JvmDefaultWithoutCompatibility
 
 @JvmDefaultWithoutCompatibility
@@ -36,6 +33,7 @@ class XMakeToolWindowFactory : ToolWindowFactory, DumbAware {
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
         val outputPanel = XMakeToolWindowOutputPanel(project)
         val outputTab = ContentFactory.getInstance().createContent(outputPanel, "Output", false)
+        outputTab.setDisposer(outputPanel)
         toolWindow.contentManager.addContent(outputTab)
 
         val problemPanel = XMakeToolWindowProblemPanel(project)
@@ -43,28 +41,8 @@ class XMakeToolWindowFactory : ToolWindowFactory, DumbAware {
         toolWindow.contentManager.addContent(problemTab)
 
         toolWindow.contentManager.setSelectedContent(outputTab)
+        project.xmakeConsoleService.register(toolWindow, outputPanel, problemPanel, outputTab)
     }
 }
 
-// the xmake tool windows
-val Project.xmakeToolWindow: ToolWindow?
-    get() = ToolWindowManager.getInstance(this).getToolWindow("XMake")
-
-// the xmake output panel
-val Project.xmakeOutputPanel: XMakeToolWindowOutputPanel
-    get() = this.xmakeToolWindow?.contentManager?.getContent(0)?.component as XMakeToolWindowOutputPanel
-
-// the xmake problem panel
-val Project.xmakeProblemPanel: XMakeToolWindowProblemPanel
-    get() = this.xmakeToolWindow?.contentManager?.getContent(1)?.component as XMakeToolWindowProblemPanel
-
-// the xmake console view
-val Project.xmakeConsoleView: ConsoleView
-    get() = this.xmakeOutputPanel.consoleView
-
-// the xmake problem list
-var Project.xmakeProblemList: List<XMakeProblem>
-    get() = this.xmakeProblemPanel.problems
-    set(value) {
-        this.xmakeProblemPanel.problems = value
-    }
+const val XMAKE_TOOL_WINDOW_ID = "XMake"

--- a/src/main/kotlin/io/xmake/project/console/XMakeToolWindowOutputPanel.kt
+++ b/src/main/kotlin/io/xmake/project/console/XMakeToolWindowOutputPanel.kt
@@ -18,7 +18,7 @@
  * @file        XMakeToolWindowOutputPanel.kt
  *
  */
-package io.xmake.project
+package io.xmake.project.console
 
 import com.intellij.execution.filters.TextConsoleBuilderFactory
 import com.intellij.execution.ui.ConsoleView
@@ -30,9 +30,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.SimpleToolWindowPanel
 import com.intellij.openapi.util.Disposer
 
-class XMakeToolWindowOutputPanel(// the project
-    val project: Project
-) : SimpleToolWindowPanel(false), Disposable {
+class XMakeToolWindowOutputPanel(project: Project) : SimpleToolWindowPanel(false), Disposable {
 
     // the toolbar
     val toolbar: ActionToolbar = run {
@@ -66,11 +64,5 @@ class XMakeToolWindowOutputPanel(// the project
 
     // dispose
     override fun dispose() {
-    }
-
-    // show panel
-    fun showPanel() {
-        val contentManager = project.xmakeToolWindow?.contentManager
-        contentManager?.setSelectedContent(contentManager.getContent(0)!!)
     }
 }

--- a/src/main/kotlin/io/xmake/project/console/XMakeToolWindowProblemPanel.kt
+++ b/src/main/kotlin/io/xmake/project/console/XMakeToolWindowProblemPanel.kt
@@ -18,7 +18,7 @@
  * @file        XMakeToolWindowProblemPanel.kt
  *
  */
-package io.xmake.project
+package io.xmake.project.console
 
 import com.intellij.execution.RunManager
 import com.intellij.openapi.actionSystem.ActionManager

--- a/src/main/kotlin/io/xmake/run/XMakeRunConfiguration.kt
+++ b/src/main/kotlin/io/xmake/run/XMakeRunConfiguration.kt
@@ -175,7 +175,7 @@ class XMakeRunConfiguration(
             }
         }
 
-        project.xmakeConsoleService.currentConsole.let { console ->
+        project.xmakeConsoleService.whenReady { console ->
             // clear console first
             console.clear()
 

--- a/src/main/kotlin/io/xmake/run/XMakeRunConfiguration.kt
+++ b/src/main/kotlin/io/xmake/run/XMakeRunConfiguration.kt
@@ -38,7 +38,7 @@ import com.intellij.util.xmlb.annotations.Transient
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import io.xmake.project.toolkit.Toolkit
 import io.xmake.project.toolkit.ToolkitManager
-import io.xmake.project.xmakeConsoleView
+import io.xmake.project.console.xmakeConsoleService
 import io.xmake.shared.xmakeConfiguration
 import io.xmake.utils.SystemUtils
 import io.xmake.utils.info.XMakeInfoManager
@@ -175,21 +175,23 @@ class XMakeRunConfiguration(
             }
         }
 
-        // clear console first
-        project.xmakeConsoleView.clear()
+        project.xmakeConsoleService.currentConsole.let { console ->
+            // clear console first
+            console.clear()
 
-        // configure and run it
-        val xmakeConfiguration = project.xmakeConfiguration
-        if (xmakeConfiguration.changed) {
-            SystemUtils.runvInConsole(project, xmakeConfiguration.configurationCommandLine)
-                ?.addProcessListener(object : ProcessListener {
-                    override fun processTerminated(e: ProcessEvent) {
-                        SystemUtils.runvInConsole(project, runCommandLine, false, true, true)
-                    }
-                })
-            xmakeConfiguration.changed = false
-        } else {
-            SystemUtils.runvInConsole(project, runCommandLine, true, true, true)
+            // configure and run it
+            val xmakeConfiguration = project.xmakeConfiguration
+            if (xmakeConfiguration.changed) {
+                SystemUtils.runvInConsole(project, console, xmakeConfiguration.configurationCommandLine)
+                    ?.addProcessListener(object : ProcessListener {
+                        override fun processTerminated(e: ProcessEvent) {
+                            SystemUtils.runvInConsole(project, console, runCommandLine, false, true, true)
+                        }
+                    })
+                xmakeConfiguration.changed = false
+            } else {
+                SystemUtils.runvInConsole(project, console, runCommandLine, true, true, true)
+            }
         }
 
         // does not use builtin run console panel

--- a/src/main/kotlin/io/xmake/run/XMakeRunner.kt
+++ b/src/main/kotlin/io/xmake/run/XMakeRunner.kt
@@ -31,6 +31,7 @@ import io.xmake.project.console.XMakeConsole
 import io.xmake.project.console.xmakeConsoleService
 import io.xmake.utils.Logger
 import io.xmake.utils.SystemUtils
+import org.jetbrains.concurrency.AsyncPromise
 import org.jetbrains.concurrency.Promise
 
 open class XMakeRunner : XMakeDefaultRunner() {
@@ -63,9 +64,15 @@ open class XMakeRunner : XMakeDefaultRunner() {
             return super.execute(environment, state)
         }
 
-        return org.jetbrains.concurrency.resolvedPromise(
-            executeDebug(state, environment, environment.project.xmakeConsoleService.currentConsole)
-        )
+        val promise = AsyncPromise<RunContentDescriptor?>()
+        environment.project.xmakeConsoleService.whenReady(onUnavailable = { promise.setError(it) }) { console ->
+            try {
+                promise.setResult(executeDebug(state, environment, console))
+            } catch (e: Exception) {
+                promise.setError(e)
+            }
+        }
+        return promise
     }
 
     private fun executeDebug(

--- a/src/main/kotlin/io/xmake/run/XMakeRunner.kt
+++ b/src/main/kotlin/io/xmake/run/XMakeRunner.kt
@@ -25,12 +25,13 @@ import com.intellij.execution.configurations.RunProfileState
 import com.intellij.execution.executors.DefaultDebugExecutor
 import com.intellij.execution.executors.DefaultRunExecutor
 import com.intellij.execution.runners.ExecutionEnvironment
-import com.intellij.execution.runners.ProgramRunner
 import com.intellij.execution.ui.RunContentDescriptor
 import io.xmake.debug.XMakeDebugSession
+import io.xmake.project.console.XMakeConsole
+import io.xmake.project.console.xmakeConsoleService
 import io.xmake.utils.Logger
-import com.intellij.openapi.project.Project
 import io.xmake.utils.SystemUtils
+import org.jetbrains.concurrency.Promise
 
 open class XMakeRunner : XMakeDefaultRunner() {
 
@@ -54,22 +55,35 @@ open class XMakeRunner : XMakeDefaultRunner() {
 
     override fun getRunnerId(): String = "XMakeRunner"
 
-    override fun doExecute(state: RunProfileState, environment: ExecutionEnvironment): RunContentDescriptor? {
+    override fun execute(
+        environment: ExecutionEnvironment,
+        state: RunProfileState
+    ): Promise<RunContentDescriptor?> {
+        if (environment.executor.id != DefaultDebugExecutor.EXECUTOR_ID) {
+            return super.execute(environment, state)
+        }
+
+        return org.jetbrains.concurrency.resolvedPromise(
+            executeDebug(state, environment, environment.project.xmakeConsoleService.currentConsole)
+        )
+    }
+
+    private fun executeDebug(
+        state: RunProfileState,
+        environment: ExecutionEnvironment,
+        console: XMakeConsole
+    ): RunContentDescriptor? {
         val configuration = environment.runProfile
         if (configuration !is XMakeRunConfiguration) {
             return null
         }
 
-        if (environment.executor.id == DefaultDebugExecutor.EXECUTOR_ID) {
-            // Check if debug is available before starting debug session
-            if (!SystemUtils.isNativeDebugAvailable()) {
-                Logger.w(TAG, "Debug functionality is not available in this IDE. Please use CLion for C/C++ debugging.")
-                return null
-            }
-            return XMakeDebugSession(state, environment).startDebugSession()
+        // Check if debug is available before starting debug session
+        if (!SystemUtils.isNativeDebugAvailable()) {
+            Logger.w(TAG, "Debug functionality is not available in this IDE. Please use CLion for C/C++ debugging.")
+            return null
         }
-
-        return super.doExecute(state, environment)
+        return XMakeDebugSession(state, environment, console).startDebugSession()
     }
     
     companion object {

--- a/src/main/kotlin/io/xmake/utils/SystemUtils.kt
+++ b/src/main/kotlin/io/xmake/utils/SystemUtils.kt
@@ -29,6 +29,7 @@ import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.application.ApplicationManager
 import io.xmake.debug.DebugModuleLoader
+import io.xmake.project.console.XMakeConsole
 import io.xmake.project.toolkit.activatedToolkit
 import io.xmake.shared.XMakeProblem
 import io.xmake.utils.exception.XMakeToolkitNotSetException
@@ -91,11 +92,12 @@ object SystemUtils {
 
     fun runvInConsole(
         project: Project,
+        console: XMakeConsole,
         commandLine: GeneralCommandLine,
         showConsole: Boolean = true,
         showProblem: Boolean = false,
         showExitCode: Boolean = false
-    ) = runProcessWithHandler(project, commandLine, showConsole, showProblem, showExitCode) {
+    ) = runProcessWithHandler(project, console, commandLine, showConsole, showProblem, showExitCode) {
         try {
             val activatedToolkit = project.activatedToolkit
             if (activatedToolkit != null) {

--- a/src/main/kotlin/io/xmake/utils/execute/CommandEx.kt
+++ b/src/main/kotlin/io/xmake/utils/execute/CommandEx.kt
@@ -33,17 +33,12 @@ import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
 import com.intellij.util.io.awaitExit
+import io.xmake.project.console.XMakeConsole
 import io.xmake.project.toolkit.Toolkit
 import io.xmake.project.toolkit.ToolkitHostType.*
-import io.xmake.project.xmakeConsoleView
-import io.xmake.project.xmakeOutputPanel
-import io.xmake.project.xmakeProblemList
-import io.xmake.project.xmakeToolWindow
 import io.xmake.shared.XMakeProblem
 import io.xmake.utils.SystemUtils.parseProblem
 import io.xmake.utils.extension.ToolkitHostExtension
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
 
 private val Log = logger<GeneralCommandLine>()
 
@@ -109,6 +104,7 @@ suspend fun runProcess(process: Process): Pair<Result<String>, Int>{
 
 fun runProcessWithHandler(
     project: Project,
+    console: XMakeConsole,
     command: GeneralCommandLine,
     showConsole: Boolean = true,
     showProblem: Boolean = false,
@@ -127,32 +123,26 @@ fun runProcessWithHandler(
     processHandler.addProcessListener(object : ProcessListener {
         override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {
             super.onTextAvailable(event, outputType)
-            project.xmakeConsoleView.print(event.text, ConsoleViewContentType.getConsoleViewType(outputType))
+            console.print(event.text, ConsoleViewContentType.getConsoleViewType(outputType))
             content += event.text
         }
     })
 
     if (showConsole) {
-        com.intellij.openapi.application.ApplicationManager.getApplication().invokeLater {
-            project.xmakeToolWindow?.show {
-                project.xmakeOutputPanel.showPanel()
-            }
-        }
+        console.showOutput()
     }
 
     if (showProblem) {
         processHandler.addProcessListener(object : ProcessListener {
             override fun processTerminated(e: ProcessEvent) {
-                runBlocking(Dispatchers.Default) {
-                    val problems = mutableListOf<XMakeProblem>()
-                    content.split(Regex("\\r\\n|\\n|\\r")).forEach {
-                        val problem = parseProblem(it.trim())
-                        if (problem !== null) {
-                            problems.add(problem)
-                        }
+                val problems = mutableListOf<XMakeProblem>()
+                content.split(Regex("\\r\\n|\\n|\\r")).forEach {
+                    val problem = parseProblem(it.trim())
+                    if (problem !== null) {
+                        problems.add(problem)
                     }
-                    project.xmakeProblemList = problems
                 }
+                console.updateProblems(problems)
             }
         })
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -37,7 +37,7 @@
         <projectConfigurable instance="io.xmake.project.XMakeSettingsConfigurable"
                              displayName="Xmake" groupId="build"/>
 
-        <toolWindow id="XMake" anchor="bottom" factoryClass="io.xmake.project.XMakeToolWindowFactory"
+        <toolWindow id="XMake" anchor="bottom" factoryClass="io.xmake.project.console.XMakeToolWindowFactory"
                     icon="/icons/xmake-dark.svg"/>
 
         <!-- run configurations -->


### PR DESCRIPTION
**Initialized the XMake console before console-dependent GUI actions run**

Fixes #103.

## _What Changed_
- Added a project-level `XMakeConsoleService` that owns console availability and initializes it through the registered XMake tool window.
- Introduced a typed `XMakeConsole` capability and passed it explicitly through actions, process execution, run configurations, and debug sessions.
- Replaced fixed content indexes, panel casts, and reverse lookups through tool window UI components with registered console references.
- Added `XMakeProjectAction` and `XMakeConsoleAction` boundaries so IntelliJ action events are reduced to stable project dependencies before console readiness is resolved.
- Ensured console-dependent actions, Quick Start, run configurations, and debug execution initialize the console on the IntelliJ UI thread before using it.
- Kept console initialization separate from visibility: commands initialize the console when required, while the tool window is shown only when the command requests output.

## _Why_
- Issue #103 reports that XMake commands invoked from the GUI can either throw a `NullPointerException` or silently fail to execute when the XMake tool window has not been opened yet.
- Tool window registration makes the window known to IntelliJ, but it does not guarantee that `ToolWindowFactory.createToolWindowContent` has already created its content. The previous accessors immediately read fixed content positions and cast their components, so actions could run before those components existed.
- Console commands should depend on an initialized console capability, not on whether the user has already opened or made the tool window visible. Centralizing readiness in a project service gives every entry point the same lifecycle behavior without forcing the UI to appear.
- `AnActionEvent` and its data context belong to the immediate IntelliJ action invocation. Extracting the project before resolving console readiness avoids retaining event-scoped state while keeping individual actions focused on their command logic.

## _Impact_
*XMake GUI and menu actions can now execute before the XMake tool window has been opened, without throwing during panel lookup or dropping the command.*

*Console output, problem reporting, run configurations, and debugging use the same initialized console instance, while existing tool window visibility behavior remains unchanged.*

*Fork validation completed successfully with the plugin build, full Plugin Verifier, and artifact upload.*