### PR TITLE
Expand IntelliJ macros in XMake working directories

### DIFF
--- a/src/main/kotlin/io/xmake/debug/XMakeDebugSession.kt
+++ b/src/main/kotlin/io/xmake/debug/XMakeDebugSession.kt
@@ -107,7 +107,7 @@ class XMakeDebugSession(
         val buildCommandLine = xmakeConfiguration.makeCommandLine(
             mutableListOf("build", configuration.runTarget).filter { it != "default" && it.isNotBlank() },
             EnvironmentVariablesData.DEFAULT
-        ).withWorkDirectory(project.basePath)
+        )
 
         val buildProcess = SystemUtils.runvInConsole(project, console, buildCommandLine, false, true, false)
         buildProcess?.waitFor()
@@ -304,7 +304,7 @@ class XMakeDebugSession(
                 } else {
                     emptyList()
                 }
-                val workingDir = configuration.runWorkingDir.takeIf { it.isNotBlank() }
+                val workingDir = configuration.resolvedWorkingDirectory.takeIf { it.isNotBlank() }
                     ?: project.basePath
                     ?: File(targetPath).absoluteFile.parent
                 val debugProcess = DebugModuleLoader.createDebugProcess(
@@ -358,7 +358,6 @@ class XMakeDebugSession(
             parameters,
             EnvironmentVariablesData.DEFAULT
         ).apply {
-            withWorkDirectory(project.basePath)
             withEnvironment("XMAKE_SKIP_HISTORY", "1")
             withEnvironment("XMAKE_ROOT", "y")
             withEnvironment("XMAKE_COLOR_TERM", "nocolor")

--- a/src/main/kotlin/io/xmake/project/console/XMakeToolWindowProblemPanel.kt
+++ b/src/main/kotlin/io/xmake/project/console/XMakeToolWindowProblemPanel.kt
@@ -40,6 +40,7 @@ import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.panel
 import io.xmake.icons.XMakeIcons
 import io.xmake.run.XMakeRunConfiguration
+import io.xmake.utils.path.WorkingDirectoryResolver
 import io.xmake.shared.XMakeProblem
 import java.awt.Font
 import java.awt.event.MouseAdapter
@@ -141,10 +142,12 @@ class XMakeToolWindowProblemPanel(project: Project) : SimpleToolWindowPanel(fals
                         if (File(filename).exists()) {
                             filename = File(filename).absolutePath
                         } else {
+                            val configuration =
+                                RunManager.getInstance(project).selectedConfiguration?.configuration as XMakeRunConfiguration
                             filename = File(
-                                // Todo: Check if correct
-                                (RunManager.getInstance(project).selectedConfiguration?.configuration as XMakeRunConfiguration).runWorkingDir
-                                , filename).absolutePath
+                                WorkingDirectoryResolver.resolve(project, configuration.runWorkingDir),
+                                filename,
+                            ).absolutePath
                         }
 
                         // open this file

--- a/src/main/kotlin/io/xmake/run/XMakeRunConfiguration.kt
+++ b/src/main/kotlin/io/xmake/run/XMakeRunConfiguration.kt
@@ -36,7 +36,10 @@ import com.intellij.util.xmlb.XmlSerializer
 import com.intellij.util.xmlb.annotations.OptionTag
 import com.intellij.util.xmlb.annotations.Transient
 import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.util.IncorrectOperationException
+import io.xmake.utils.path.WorkingDirectoryResolver
 import io.xmake.project.toolkit.Toolkit
+import io.xmake.project.toolkit.ToolkitHostType
 import io.xmake.project.toolkit.ToolkitManager
 import io.xmake.project.console.xmakeConsoleService
 import io.xmake.shared.xmakeConfiguration
@@ -45,7 +48,9 @@ import io.xmake.utils.info.XMakeInfoManager
 import io.xmake.utils.info.xmakeInfo
 import io.xmake.debug.DapDriverDetector
 import org.jdom.Element
-import kotlin.io.path.Path
+import java.nio.file.Files
+import java.nio.file.InvalidPathException
+import java.nio.file.Path
 
 class XMakeRunConfiguration(
     project: Project, name: String, factory: ConfigurationFactory
@@ -81,6 +86,9 @@ class XMakeRunConfiguration(
 
     @OptionTag(tag = "workingDirectory")
     var runWorkingDir: String = project.basePath ?: ""
+
+    val resolvedWorkingDirectory: String
+        get() = WorkingDirectoryResolver.resolve(project, runWorkingDir, runToolkit)
 
     @OptionTag(tag = "buildDirectory")
     var buildDirectory: String = ""
@@ -123,7 +131,6 @@ class XMakeRunConfiguration(
             // make command line
             return project.xmakeConfiguration
                 .makeCommandLine(parameters, runEnvironment)
-                .withWorkDirectory(Path(runWorkingDir).toFile())
                 .withCharset(Charsets.UTF_8)
         }
 
@@ -153,9 +160,24 @@ class XMakeRunConfiguration(
             throw RuntimeConfigurationError("Xmake toolkit is not set!")
         }
 
-        // Todo: Check whether working directory is valid.
-        if (runWorkingDir.isBlank()){
+        if (runWorkingDir.isBlank()) {
             throw RuntimeConfigurationError("Working directory is not set!")
+        }
+
+        if (runToolkit?.host?.type == ToolkitHostType.LOCAL) {
+            val resolvedWorkingDirectory = try {
+                WorkingDirectoryResolver.resolve(project, runWorkingDir, validation = true)
+            } catch (e: IncorrectOperationException) {
+                throw RuntimeConfigurationError(e.message ?: "Working directory contains invalid macros")
+            }
+            val workingDirectory = try {
+                Path.of(resolvedWorkingDirectory)
+            } catch (_: InvalidPathException) {
+                throw RuntimeConfigurationError("Working directory is invalid: $resolvedWorkingDirectory")
+            }
+            if (!Files.isDirectory(workingDirectory)) {
+                throw RuntimeConfigurationError("Working directory does not exist: $resolvedWorkingDirectory")
+            }
         }
     }
 

--- a/src/main/kotlin/io/xmake/run/XMakeRunConfigurationEditor.kt
+++ b/src/main/kotlin/io/xmake/run/XMakeRunConfigurationEditor.kt
@@ -43,6 +43,7 @@ import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.layout.ComboBoxPredicate
 import io.xmake.project.directory.ui.DirectoryBrowser
 import io.xmake.project.target.TargetManager
+import io.xmake.utils.path.WorkingDirectoryResolver
 import io.xmake.project.toolkit.Toolkit
 import io.xmake.project.toolkit.ui.ToolkitComboBox
 import io.xmake.project.toolkit.ui.ToolkitListItem
@@ -148,7 +149,7 @@ class XMakeRunConfigurationEditor(
             xmakeInfo.targets.plus("default")
         } else {
             (runConfiguration.runToolkit?.let {
-                TargetManager.getInstance(project).detectXMakeTarget(it, runConfiguration.runWorkingDir)
+                TargetManager.getInstance(project).detectXMakeTarget(it, runConfiguration.resolvedWorkingDirectory)
             } ?: emptyList()).plus("default")
         }.distinct().toList()
         targetsModel.addAll(targets)
@@ -535,7 +536,11 @@ class XMakeRunConfigurationEditor(
         row("Sync Directory:") {
             button("Upload") {
                 toolkitComboBox.activatedToolkit?.let { toolkit ->
-                    val workingDirectoryPath = workingDirectoryBrowser.text
+                    val workingDirectoryPath = WorkingDirectoryResolver.resolve(
+                        project,
+                        workingDirectoryBrowser.text,
+                        toolkit,
+                    )
 
                     scope.launch(Dispatchers.IO) {
                         if (toolkit.isOnRemote) {

--- a/src/main/kotlin/io/xmake/shared/XMakeConfiguration.kt
+++ b/src/main/kotlin/io/xmake/shared/XMakeConfiguration.kt
@@ -180,10 +180,7 @@ class XMakeConfiguration(val project: Project) {
         return GeneralCommandLine(project.activatedToolkit?.path ?: "xmake")
             .withParameters(parameters)
             .withCharset(Charsets.UTF_8)
-            // Todo: Check if correct.
-            .withWorkDirectory(
-                configuration.runWorkingDir
-            )
+            .withWorkDirectory(configuration.resolvedWorkingDirectory)
             .withEnvironment(environmentVariables.envs)
             .withRedirectErrorStream(true)
     }
@@ -202,4 +199,3 @@ val Project.xmakeConfiguration: XMakeConfiguration
 
 val Project.xmakeConfigurationOrNull: XMakeConfiguration?
     get() = this.getService(XMakeConfiguration::class.java) ?: null
-

--- a/src/main/kotlin/io/xmake/utils/execute/Sync.kt
+++ b/src/main/kotlin/io/xmake/utils/execute/Sync.kt
@@ -247,7 +247,7 @@ fun transferFolderByToolkit(
     project: Project,
     toolkit: Toolkit,
     direction: SyncDirection,
-    directoryPath: String = (RunManager.getInstance(project).selectedConfiguration?.configuration as XMakeRunConfiguration).runWorkingDir,
+    directoryPath: String = (RunManager.getInstance(project).selectedConfiguration?.configuration as XMakeRunConfiguration).resolvedWorkingDirectory,
     relativePath: String? = null,
     onComplete: () -> Unit = {},
 ) {

--- a/src/main/kotlin/io/xmake/utils/path/WorkingDirectoryResolver.kt
+++ b/src/main/kotlin/io/xmake/utils/path/WorkingDirectoryResolver.kt
@@ -1,0 +1,69 @@
+/*!A Xmake integration in IntelliJ IDEA/Clion
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (C) 2015-present, Xmake Open Source Community.
+ */
+package io.xmake.utils.path
+
+import com.intellij.execution.util.ProgramParametersConfigurator
+import com.intellij.execution.wsl.WSLDistribution
+import com.intellij.execution.wsl.WslPath
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.io.OSAgnosticPathUtil
+import io.xmake.project.toolkit.Toolkit
+import io.xmake.project.toolkit.ToolkitHostType
+import java.nio.file.InvalidPathException
+import java.nio.file.Path
+
+object WorkingDirectoryResolver {
+    fun resolve(project: Project, workingDirectory: String): String =
+        resolve(project, workingDirectory, validation = false)
+
+    fun resolve(project: Project, workingDirectory: String, validation: Boolean): String =
+        ProgramParametersConfigurator().apply { setValidation(validation) }
+            .expandPathAndMacros(workingDirectory, null, project)
+            ?: workingDirectory
+
+    fun resolve(project: Project, workingDirectory: String, toolkit: Toolkit?): String =
+        when (toolkit?.host?.type) {
+            ToolkitHostType.LOCAL -> resolve(project, workingDirectory)
+            ToolkitHostType.WSL -> {
+                (toolkit.host.target as? WSLDistribution)?.let { distribution ->
+                    resolveForWsl(project, workingDirectory, distribution)
+                } ?: workingDirectory
+            }
+            ToolkitHostType.SSH, null -> workingDirectory
+        }
+
+    fun resolveForWsl(
+        project: Project,
+        workingDirectory: String,
+        distribution: WSLDistribution,
+    ): String = convertToWslPath(resolve(project, workingDirectory), distribution::getWslPath)
+
+    internal fun convertToWslPath(
+        workingDirectory: String,
+        converter: (Path) -> String?,
+    ): String {
+        if (!OSAgnosticPathUtil.isAbsoluteDosPath(workingDirectory) && !WslPath.isWslUncPath(workingDirectory)) {
+            return workingDirectory
+        }
+        val path = try {
+            Path.of(workingDirectory)
+        } catch (_: InvalidPathException) {
+            return workingDirectory
+        }
+        return converter(path) ?: workingDirectory
+    }
+}


### PR DESCRIPTION
**Expanded IntelliJ macros in XMake working directories**

Fixes #68.

## _What Changed_
- Expanded IntelliJ-provided path macros through `ProgramParametersConfigurator`.
- Centralized working directory resolution and used it consistently for build, run, target detection, synchronization, problem navigation, and local debugging.
- Added local directory validation before starting XMake.
- Converted Windows and WSL UNC paths for WSL toolkits while preserving native Linux paths.
- Left SSH paths unchanged because the plugin has no reliable local-to-remote directory mapping.

## _Why_
Working directory values were previously passed directly to the process launcher or handled differently across execution paths. As a result, IntelliJ macros could remain unresolved and prevent XMake from starting.

Using IntelliJ's macro expansion API gives each execution path the same behavior. The `$WORKSPACE_DIR$` value shown in the original report is not an IntelliJ path macro; `$PROJECT_DIR$` is the platform-provided equivalent.

WSL paths require host conversion after macro expansion. SSH does not provide enough mapping information to do this safely, so SSH paths are deliberately left unchanged.

## _Validation_
- Verified `$PROJECT_DIR$`, path suffixes, local toolkit expansion, SSH path preservation, and native Linux path preservation on Ubuntu, macOS, and Windows.
- Verified Windows drive and WSL UNC conversion, including an Ubuntu 22.04 WSL smoke test.
- Verified plugin compatibility with CLion and IntelliJ IDEA 2026.1 and 2026.2.

Temporary test and workflow files were removed after validation and are not included in this PR.

## _Impact_
*XMake working directories can now use IntelliJ-provided path macros such as `$PROJECT_DIR$` without passing unresolved paths to XMake.*

*Local and WSL paths are resolved for their host environment. SSH directory mapping and remote debugging remain outside the scope of this change.*