### PR TITLE
Update plugin version to 1.4.20

### DIFF
--- a/change-notes.html
+++ b/change-notes.html
@@ -1,3 +1,11 @@
+<strong>1.4.20</strong>
+<ul>
+    <li>[FIX]: Fix XMake command execution before the tool window is initialized</li>
+    <li>[FIX]: Fix WSL and SSH project synchronization and generation timing</li>
+    <li>[FIX]: Save XMake files before build, run, and debug commands</li>
+    <li>[FIX]: Preserve CLion DAP launch arguments, working directory, and environment variables</li>
+    <li>[IMPROVE]: Support IntelliJ path macros in XMake working directories</li>
+</ul>
 <strong>1.4.19</strong>
 <ul>
     <li>[IMPROVE]: Automatically build target before starting a debug session</li>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-pluginVersion=1.4.19
-pluginSinceBuild=261
+pluginVersion=1.4.20
+pluginSinceBuild=251
 runIdeVersion=2026.1.4
 
 org.jetbrains.intellij.platform.intellijPlatformIdesCacheEnabled=true


### PR DESCRIPTION
**Update the plugin version to 1.4.20.**

## _What Changed_

- Bumped the plugin version from 1.4.19 to 1.4.20.
- Changed the minimum supported build from 261 to 251.
- Added the 1.4.20 release notes.

## _Why_

The compatibility range was rechecked against stable IntelliJ Platform releases. CLion and IntelliJ IDEA passed Plugin Verifier from 2025.1 / build 251 onward; the 2024.3 line did not. The minimum build is therefore updated from 261 to 251.

This PR prepares the 1.4.20 version and release notes. It remains separate from the documentation PR.

## _Impact_

*The next release is version 1.4.20 and supports IntelliJ Platform 2025.1 or later.*

*This PR changes release metadata only.*