### PR TITLE
Generate the complete plugin distribution in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,3 +40,4 @@ jobs:
         with:
           name: xmake-idea.zip
           path: ./build/distributions/xmake-idea.zip
+          archive: false

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,13 +4,13 @@
 
 set -e
 
-echo "Building xmake-idea plugin..."
-echo "This will build CLion debug module first, then the main plugin."
+echo "Building and packaging xmake-idea plugin..."
+echo "This will run tests and create the complete plugin distribution ZIP."
 
-# Build the entire project
-./gradlew build
+# Run the normal build and explicitly assemble the deployable plugin archive.
+./gradlew build buildPlugin
 
 echo "Build completed successfully!"
-echo "The plugin JAR is available in build/distributions/"
+echo "The complete plugin ZIP is available at build/distributions/xmake-idea.zip"
 echo ""
 echo "To run the plugin in development mode, use: ./scripts/run.sh"


### PR DESCRIPTION
**Generated the complete plugin distribution explicitly in CI**

Fixes #117.

## _What Changed_

- Updated `scripts/build.sh` to run `./gradlew build buildPlugin`.
- Corrected the build output message to reference `build/distributions/xmake-idea.zip`.
- Configured the artifact upload step to upload `xmake-idea.zip` as-is instead of wrapping it in another ZIP.

## _Why_

First, previous versions embedded the debug module in the main JAR, so publishing that JAR happened to work. The plugin now uses the standard IntelliJ Platform content-module layout, where the debug module is packaged separately under `lib/modules`. Consequently, the main JAR is no longer a complete plugin, and the full distribution ZIP must be published.

Because the release artifact changed from a self-contained JAR to a directory-based plugin ZIP, CI also needed to build that distribution explicitly. However, the CI script retained its existing `./gradlew build` command when it was reorganized. GitHub Actions still produced the ZIP only because the later `verifyPlugin` task invoked `buildPlugin` indirectly, which obscured the distinction between the main JAR and the complete distribution.

Finally, even after `verifyPlugin` produced the correct distribution ZIP, the artifact upload step archived that ZIP again. This additional layer did not affect the previous release flow because the published plugin was a self-contained JAR. With the standard directory-based layout, however, the installable artifact is already a ZIP. Wrapping it again produces a nested ZIP whose plugin layout cannot be recognized by IntelliJ Platform when used directly.

## _Impact_

*CI now produces a directly usable plugin ZIP for local installation and Marketplace publication.*