### PR TITLE
Update plugin version to 1.4.21

### DIFF
--- a/change-notes.html
+++ b/change-notes.html
@@ -1,3 +1,7 @@
+<strong>1.4.21</strong>
+<ul>
+    <li>[FIX]: Fix plugin distribution packaging for installation and Marketplace publication</li>
+</ul>
 <strong>1.4.20</strong>
 <ul>
     <li>[FIX]: Fix XMake command execution before the tool window is initialized</li>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=1.4.20
+pluginVersion=1.4.21
 pluginSinceBuild=251
 runIdeVersion=2026.1.4
 


### PR DESCRIPTION
**Update the plugin version to `1.4.21`.**

## _What Changed_

- Bumped the plugin version from `1.4.20` to `1.4.21`.
- Added the `1.4.21` changelog entry.

## _Why_

Version `1.4.20` was published with an incorrectly packaged plugin distribution. Since published artifacts cannot be replaced, a new version is required to release the corrected package as `1.4.21`.

## _Impact_

*This PR changes release metadata only.*