### PR TITLE
Update plugin version to 1.4.22

### DIFF
--- a/change-notes.html
+++ b/change-notes.html
@@ -1,3 +1,7 @@
+<strong>1.4.22</strong>
+<ul>
+    <li>[FIX]: Re-upload the correct distribution package.</li>
+</ul>
 <strong>1.4.21</strong>
 <ul>
     <li>[FIX]: Fix plugin distribution packaging for installation and Marketplace publication</li>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=1.4.21
+pluginVersion=1.4.22
 pluginSinceBuild=251
 runIdeVersion=2026.1.4
 


### PR DESCRIPTION
**Update the plugin version to `1.4.22`.**

## _What Changed_

- Bumped the plugin version from `1.4.21` to `1.4.22`.
- Added the `1.4.22` changelog entry.

## _Why_

Version `1.4.21` was published with an incorrectly packaged plugin distribution. Since published artifacts cannot be replaced, a new version is required to release the corrected package as `1.4.22`.

## _Impact_

*This PR changes release metadata only.*