### PR TITLE
Require IntelliJ Platform 2026.2 and JDK 25

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: jetbrains
-          java-version: 21
+          java-version: 25
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ repositories {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 intellijPlatform {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,7 @@ intellijPlatform {
 dependencies {
     intellijPlatform {
         clion(runIdeVersion)
+        bundledPlugin("intellij.ssh.plugin")
         testFramework(TestFrameworkType.Platform)
         pluginModule(implementation(project(":clion-debug")))
     }

--- a/clion-debug/build.gradle.kts
+++ b/clion-debug/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginVersion=1.4.22
-pluginSinceBuild=251
-runIdeVersion=2026.1.4
+pluginSinceBuild=262
+runIdeVersion=2026.2
 
 org.jetbrains.intellij.platform.intellijPlatformIdesCacheEnabled=true
 kotlin.stdlib.default.dependency=false

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -8,10 +8,10 @@ set -e
 echo "🔍 Verifying XMake Plugin..."
 echo ""
 
-# JAVA_HOME is set by CI (JetBrains JVM 21 via actions/setup-java)
-# If running locally, ensure JAVA_HOME points to a JDK 21+ installation
+# JAVA_HOME is set by CI (JetBrains JVM 25 via actions/setup-java)
+# If running locally, ensure JAVA_HOME points to a JDK 25+ installation
 if [ -z "$JAVA_HOME" ]; then
-    echo "⚠️  JAVA_HOME not set, using system default (requires JDK 21+)"
+    echo "⚠️  JAVA_HOME not set, using system default (requires JDK 25+)"
 fi
 
 # Run the verification task


### PR DESCRIPTION
**Raised the plugin baseline to IntelliJ Platform `2026.2` and `JDK 25`**

## _What Changed_
- Bumped `pluginSinceBuild` from `251` to `262` and `runIdeVersion` to `2026.2` in `gradle.properties`.
- Switched both the core and `clion-debug` modules to the `JDK 25` toolchain.
- Updated CI (`setup-java`) and `scripts/verify.sh` to `JDK 25`.
- Added the bundled `intellij.ssh.plugin` dependency required by the `2026.2` platform.

## _Why_
IntelliJ Platform `2026.2` is the latest official baseline and requires `JDK 25` per the official documentation.

## _Impact_
*The plugin now requires IntelliJ Platform `2026.2` or newer; older IDE versions are no longer supported.*
