### PR TITLE
Fix diagnostic navigation in the Problems tool window

### DIFF
--- a/src/main/kotlin/io/xmake/project/console/XMakeToolWindowProblemPanel.kt
+++ b/src/main/kotlin/io/xmake/project/console/XMakeToolWindowProblemPanel.kt
@@ -20,7 +20,6 @@
  */
 package io.xmake.project.console
 
-import com.intellij.execution.RunManager
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.ActionToolbar
 import com.intellij.openapi.actionSystem.DefaultActionGroup
@@ -39,13 +38,12 @@ import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.panel
 import io.xmake.icons.XMakeIcons
-import io.xmake.run.XMakeRunConfiguration
-import io.xmake.utils.path.WorkingDirectoryResolver
 import io.xmake.shared.XMakeProblem
 import java.awt.Font
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
-import java.io.File
+import java.nio.file.InvalidPathException
+import java.nio.file.Path
 import javax.swing.JList
 import javax.swing.ListSelectionModel
 
@@ -134,28 +132,22 @@ class XMakeToolWindowProblemPanel(project: Project) : SimpleToolWindowPanel(fals
 
                     // get the clicked problem
                     val index   = problemList.locationToIndex(e.getPoint())
-                    if (index < problems.size && problems[index].file !== null) {
+                    if (index in problems.indices) {
 
                         // get file path
                         val problem     = problems[index]
-                        var filename    = problem.file
-                        if (File(filename).exists()) {
-                            filename = File(filename).absolutePath
-                        } else {
-                            val configuration =
-                                RunManager.getInstance(project).selectedConfiguration?.configuration as XMakeRunConfiguration
-                            filename = File(
-                                WorkingDirectoryResolver.resolve(project, configuration.runWorkingDir),
-                                filename,
-                            ).absolutePath
-                        }
+                        val filename = resolveProblemPath(problem) ?: return
 
                         // open this file
-                        val file = LocalFileSystem.getInstance().findFileByPath(filename)
+                        val file = LocalFileSystem.getInstance().findFileByPath(filename.toString())
                         if (file !== null) {
 
+                            // compiler line and column numbers are 1-based; the editor APIs are 0-based
+                            val line = (problem.line?.toIntOrNull() ?: 1).coerceAtLeast(1) - 1
+                            val column = (problem.column?.toIntOrNull() ?: 0).coerceAtLeast(0)
+
                             // goto file:line
-                            val descriptor = OpenFileDescriptor(project, file, problem.line?.toInt() ?: 0, problem.column?.toInt() ?: 0)
+                            val descriptor = OpenFileDescriptor(project, file, line, column)
                             descriptor.navigate(true)
 
                             // highlight line
@@ -166,10 +158,6 @@ class XMakeToolWindowProblemPanel(project: Project) : SimpleToolWindowPanel(fals
                                     editor.markupModel.removeAllHighlighters()
                                     return
                                 }
-
-                                // get line offset
-                                var line = problem.line?.toInt() ?: 0
-                                if (line > 0) line -= 1
 
                                 // init box color
                                 var boxcolor = JBColor.GRAY
@@ -187,5 +175,20 @@ class XMakeToolWindowProblemPanel(project: Project) : SimpleToolWindowPanel(fals
                 }
             }
         })
+    }
+}
+
+internal fun resolveProblemPath(problem: XMakeProblem): Path? {
+    val file = problem.file ?: return null
+    val path = try {
+        Path.of(file)
+    } catch (_: InvalidPathException) {
+        return null
+    }
+
+    return if (path.isAbsolute) {
+        path.normalize()
+    } else {
+        problem.workingDirectory?.resolve(path)?.normalize()
     }
 }

--- a/src/main/kotlin/io/xmake/project/console/XMakeToolWindowProblemPanel.kt
+++ b/src/main/kotlin/io/xmake/project/console/XMakeToolWindowProblemPanel.kt
@@ -72,26 +72,19 @@ class XMakeToolWindowProblemPanel(project: Project) : SimpleToolWindowPanel(fals
         cellRenderer = object : ColoredListCellRenderer<XMakeProblem>() {
             override fun customizeCellRenderer(list: JList<out XMakeProblem>, value: XMakeProblem, index: Int, selected: Boolean, hasFocus: Boolean) {
 
-                // get file path
-                var file = value.file
-                if (file === null) {
-                    return
-                }
-
                 // init icon
-                if (value.kind == "warning") {
-                    icon = XMakeIcons.WARNING
-                } else if (value.kind == "error") {
-                    icon = XMakeIcons.ERROR
-                } else {
-                    icon = XMakeIcons.WARNING
-                }
+                icon = if (value.kind == "error") XMakeIcons.ERROR else XMakeIcons.WARNING
 
                 // init tips
                 toolTipText = value.message ?: ""
 
                 // append text
-                append("${file}(${value.line ?: "0"}): ${value.message ?: ""}", SimpleTextAttributes.REGULAR_ATTRIBUTES)
+                val file = value.file
+                if (file !== null) {
+                    append("${file}(${value.line ?: "0"}): ${value.message ?: ""}", SimpleTextAttributes.REGULAR_ATTRIBUTES)
+                } else {
+                    append(value.message ?: "", SimpleTextAttributes.REGULAR_ATTRIBUTES)
+                }
             }
         }
     }

--- a/src/main/kotlin/io/xmake/shared/XMakeProblem.kt
+++ b/src/main/kotlin/io/xmake/shared/XMakeProblem.kt
@@ -20,11 +20,13 @@
  */
 package io.xmake.shared
 
+import java.nio.file.Path
+
 class XMakeProblem(
     val file: String? = null,
     val line: String? = "0",
     val column: String? = "0",
     val kind: String? = "error",
-    val message: String? = ""
-) {
-}
+    val message: String? = "",
+    val workingDirectory: Path? = null,
+)

--- a/src/main/kotlin/io/xmake/utils/SystemUtils.kt
+++ b/src/main/kotlin/io/xmake/utils/SystemUtils.kt
@@ -56,40 +56,89 @@ object SystemUtils {
 
     // parse problems for the given line
     fun parseProblem(info: String, workingDirectory: Path? = null): XMakeProblem? {
-
-        if (SystemInfo.isWindows) {
-
-            // gbk => utf8
-            val info_utf8 = String(info.toByteArray(), charset("UTF-8"))
-
-            // parse problem info
-            val pattern = Pattern.compile("(.*?)\\(([0-9]*)\\): (.*?) .*?: (.*)")
-            val matcher = pattern.matcher(info_utf8)
-            if (matcher.find()) {
-                val file = matcher.group(1)
-                val line = matcher.group(2)
-                val kind = matcher.group(3)
-                val message = matcher.group(4)
-                return XMakeProblem(file, line, "0", kind, message, workingDirectory)
-            }
-
-        } else {
-
-            // parse problem info
-            val pattern = Pattern.compile("^(error: )?(.*?):([0-9]*):([0-9]*): (.*?): (.*)\$")
-            val matcher = pattern.matcher(info)
-            if (matcher.find()) {
-                val file = matcher.group(2)
-                val line = matcher.group(3)
-                val column = matcher.group(4)
-                val kind = matcher.group(5)
-                val message = matcher.group(6)
-                return XMakeProblem(file, line, column, kind, message, workingDirectory)
-            }
-        }
-        return null
+        // xmake diagnostics follow one of the common compiler formats below, on any host OS
+        parseGccStyleProblem(info, workingDirectory)?.let { return it }
+        parseMsvcFamilyProblem(info, workingDirectory)?.let { return it }
+        parseArmCcStyleProblem(info, workingDirectory)?.let { return it }
+        parseIarProblem(info, workingDirectory)?.let { return it }
+        return parseLineOnlyProblem(info, workingDirectory)
     }
 
+    private fun parseGccStyleProblem(info: String, workingDirectory: Path?): XMakeProblem? {
+        val pattern = Pattern.compile("^(error: )?(.*?):([0-9]*):([0-9]*): (.*?): (.*)$")
+        val matcher = pattern.matcher(info)
+        if (!matcher.find()) return null
+        return XMakeProblem(
+            file = matcher.group(2),
+            line = matcher.group(3),
+            column = matcher.group(4),
+            kind = matcher.group(5),
+            message = matcher.group(6),
+            workingDirectory = workingDirectory,
+        )
+    }
+
+    // Matches MSVC, clang-cl, and Keil C51 diagnostics: file(line[,column]): kind [Cxxxx]: message
+    private fun parseMsvcFamilyProblem(info: String, workingDirectory: Path?): XMakeProblem? {
+        val pattern = Pattern.compile("^(.*?)\\(([0-9]+)(?:,([0-9]+))?\\): (.*?): (.*)$")
+        val matcher = pattern.matcher(info)
+        if (!matcher.find()) return null
+        return XMakeProblem(
+            file = matcher.group(1).unquote(),
+            line = matcher.group(2),
+            column = matcher.group(3) ?: "0",
+            kind = matcher.group(4),
+            message = matcher.group(5),
+            workingDirectory = workingDirectory,
+        )
+    }
+
+    // Matches ARM Compiler 5 and TI diagnostics: "file", line N: kind: message
+    private fun parseArmCcStyleProblem(info: String, workingDirectory: Path?): XMakeProblem? {
+        val pattern = Pattern.compile("^\"(.*)\", line ([0-9]+): (.*?): (.*)$")
+        val matcher = pattern.matcher(info)
+        if (!matcher.find()) return null
+        return XMakeProblem(
+            file = matcher.group(1),
+            line = matcher.group(2),
+            column = "0",
+            kind = matcher.group(3),
+            message = matcher.group(4),
+            workingDirectory = workingDirectory,
+        )
+    }
+
+    // Matches IAR diagnostics that include a file reference: "file",line  Error[PeNNNN]: message
+    private fun parseIarProblem(info: String, workingDirectory: Path?): XMakeProblem? {
+        val pattern = Pattern.compile("^\"(.*)\",([0-9]+)\\s+(Error|Warning)\\[Pe[0-9]+\\]: (.*)$")
+        val matcher = pattern.matcher(info)
+        if (!matcher.find()) return null
+        return XMakeProblem(
+            file = matcher.group(1),
+            line = matcher.group(2),
+            column = "0",
+            kind = matcher.group(3),
+            message = matcher.group(4),
+            workingDirectory = workingDirectory,
+        )
+    }
+
+    // Matches line-only formats (TCC, SDCC, ...): file:line: kind [code]: message
+    private fun parseLineOnlyProblem(info: String, workingDirectory: Path?): XMakeProblem? {
+        val pattern = Pattern.compile("^(.*?):([0-9]+): (error|warning|fatal error|note)(?: [0-9]+)?: (.*)$")
+        val matcher = pattern.matcher(info)
+        if (!matcher.find()) return null
+        return XMakeProblem(
+            file = matcher.group(1),
+            line = matcher.group(2),
+            column = "0",
+            kind = matcher.group(3),
+            message = matcher.group(4),
+            workingDirectory = workingDirectory,
+        )
+    }
+
+    private fun String.unquote(): String = removePrefix("\"").removeSuffix("\"")
     fun runvInConsole(
         project: Project,
         console: XMakeConsole,
@@ -115,7 +164,6 @@ object SystemUtils {
             throw ProcessNotCreatedException(e.message ?: "", commandLine)
         }
     }
-
     fun getResourceFilePath(resourceName: String, resourceDir: String = "lib"): String? {
         val resourcePath = "/$resourceDir/$resourceName"
         val url = SystemUtils::class.java.getResource(resourcePath)

--- a/src/main/kotlin/io/xmake/utils/SystemUtils.kt
+++ b/src/main/kotlin/io/xmake/utils/SystemUtils.kt
@@ -55,7 +55,7 @@ object SystemUtils {
     }
 
     // parse problems for the given line
-    fun parseProblem(info: String): XMakeProblem? {
+    fun parseProblem(info: String, workingDirectory: Path? = null): XMakeProblem? {
 
         if (SystemInfo.isWindows) {
 
@@ -70,7 +70,7 @@ object SystemUtils {
                 val line = matcher.group(2)
                 val kind = matcher.group(3)
                 val message = matcher.group(4)
-                return XMakeProblem(file, line, "0", kind, message)
+                return XMakeProblem(file, line, "0", kind, message, workingDirectory)
             }
 
         } else {
@@ -84,7 +84,7 @@ object SystemUtils {
                 val column = matcher.group(4)
                 val kind = matcher.group(5)
                 val message = matcher.group(6)
-                return XMakeProblem(file, line, column, kind, message)
+                return XMakeProblem(file, line, column, kind, message, workingDirectory)
             }
         }
         return null

--- a/src/main/kotlin/io/xmake/utils/execute/CommandEx.kt
+++ b/src/main/kotlin/io/xmake/utils/execute/CommandEx.kt
@@ -135,7 +135,7 @@ fun runProcessWithHandler(
             override fun processTerminated(e: ProcessEvent) {
                 val problems = mutableListOf<XMakeProblem>()
                 content.split(Regex("\\r\\n|\\n|\\r")).forEach {
-                    val problem = parseProblem(it.trim())
+                    val problem = parseProblem(it.trim(), command.workDirectory?.toPath())
                     if (problem !== null) {
                         problems.add(problem)
                     }


### PR DESCRIPTION
**Preserved the command working directory and fixed line numbers when navigating from XMake diagnostics**

## _What Changed_
- Added a `workingDirectory` field to `XMakeProblem` that records the ***working directory of the command that produced the diagnostic***.
- Resolved relative problem paths in the Problems tool window against that working directory instead of the currently selected run configuration.
- Replaced the previous file-based resolution with `java.nio.file.Path`-based normalization and safe handling of invalid paths.
- Converted the 1-based line and column numbers reported by compilers to 0-based editor coordinates, so the opened line matches the highlighted line.
- Made diagnostic parsing accept gcc/clang, MSVC-family (including clang-cl and Keil C51), ARM Compiler, TI, IAR, and line-only (TCC/SDCC) formats on any host OS, so the Problems panel is populated regardless of the compiler toolchain.

## _Why_
- ***XMake diagnostics often contain relative paths.*** The Problems panel previously resolved them against the working directory of the currently selected run configuration, which is not necessarily the directory the failing command ran in, so clicking a diagnostic could open the wrong file or fail to open anything.
- ***The command that produced the diagnostic is the only reliable context.*** Recording the working directory when the diagnostic is parsed and resolving against it keeps navigation correct regardless of the currently selected configuration.
- ***Compiler positions are 1-based while editor coordinates are 0-based.*** Passing the line through unchanged opened the file one line below the highlighted diagnostic.
- ***Diagnostic format depends on the toolchain, not the host OS.*** The previous parser accepted MSVC-style lines on Windows and gcc/clang-style lines elsewhere, so Windows builds using gcc/clang or clang-cl never produced problem entries.

## _Impact_
*Diagnostics from common desktop and embedded toolchains are now parsed, and clicking one opens the correct file and line, regardless of which run configuration is currently selected.*
