### PR TITLE
Route XMake builds through ProjectTaskManager

### DIFF
--- a/src/main/kotlin/io/xmake/actions/BuildAction.kt
+++ b/src/main/kotlin/io/xmake/actions/BuildAction.kt
@@ -21,32 +21,25 @@
 package io.xmake.actions
 
 import com.intellij.openapi.project.Project
-import io.xmake.project.console.XMakeConsole
+import io.xmake.build.XMakeBuildTask
 import io.xmake.project.xmakeSettings
+import io.xmake.run.XMakeRunConfiguration
 import io.xmake.run.command.XMakeCommandFactory
-import io.xmake.run.command.XMakeConsoleOptions
-import io.xmake.run.command.xmakeExecutionService
 
-class BuildAction : XMakeCommandAction() {
+class BuildAction : XMakeBuildAction() {
 
-    override suspend fun execute(
+    override fun createTask(
         project: Project,
-        console: XMakeConsole,
+        configuration: XMakeRunConfiguration,
         commands: XMakeCommandFactory,
-    ) {
-        val execution = project.xmakeExecutionService
-        execution.execute(console, commands.createConfigure())
-        execution.execute(
-            console,
-            commands.createBuild(),
-            XMakeConsoleOptions(showProblems = true, showExitCode = true),
-        )
-        if (project.xmakeSettings.state.autoUpdateCompileCommands) {
-            execution.execute(
-                console,
-                commands.createUpdateCompileCommands(),
-                XMakeConsoleOptions(showConsole = false, showProblems = true, showExitCode = true),
-            )
-        }
-    }
+    ): XMakeBuildTask = XMakeBuildTask(
+        presentableName = "Build '${configuration.name}'",
+        commands = buildList {
+            add(commands.createConfigure())
+            add(commands.createBuild())
+            if (project.xmakeSettings.state.autoUpdateCompileCommands) {
+                add(commands.createUpdateCompileCommands())
+            }
+        },
+    )
 }

--- a/src/main/kotlin/io/xmake/actions/CleanAction.kt
+++ b/src/main/kotlin/io/xmake/actions/CleanAction.kt
@@ -21,24 +21,18 @@
 package io.xmake.actions
 
 import com.intellij.openapi.project.Project
-import io.xmake.project.console.XMakeConsole
+import io.xmake.build.XMakeBuildTask
+import io.xmake.run.XMakeRunConfiguration
 import io.xmake.run.command.XMakeCommandFactory
-import io.xmake.run.command.XMakeConsoleOptions
-import io.xmake.run.command.xmakeExecutionService
 
-class CleanAction : XMakeCommandAction() {
+class CleanAction : XMakeBuildAction() {
 
-    override suspend fun execute(
+    override fun createTask(
         project: Project,
-        console: XMakeConsole,
+        configuration: XMakeRunConfiguration,
         commands: XMakeCommandFactory,
-    ) {
-        val execution = project.xmakeExecutionService
-        execution.execute(console, commands.createConfigure())
-        execution.execute(
-            console,
-            commands.createClean(),
-            XMakeConsoleOptions(showExitCode = true),
-        )
-    }
+    ): XMakeBuildTask = XMakeBuildTask(
+        presentableName = "Clean '${configuration.name}'",
+        commands = listOf(commands.createConfigure(), commands.createClean()),
+    )
 }

--- a/src/main/kotlin/io/xmake/actions/RebuildAction.kt
+++ b/src/main/kotlin/io/xmake/actions/RebuildAction.kt
@@ -21,24 +21,18 @@
 package io.xmake.actions
 
 import com.intellij.openapi.project.Project
-import io.xmake.project.console.XMakeConsole
+import io.xmake.build.XMakeBuildTask
+import io.xmake.run.XMakeRunConfiguration
 import io.xmake.run.command.XMakeCommandFactory
-import io.xmake.run.command.XMakeConsoleOptions
-import io.xmake.run.command.xmakeExecutionService
 
-class RebuildAction : XMakeCommandAction() {
+class RebuildAction : XMakeBuildAction() {
 
-    override suspend fun execute(
+    override fun createTask(
         project: Project,
-        console: XMakeConsole,
+        configuration: XMakeRunConfiguration,
         commands: XMakeCommandFactory,
-    ) {
-        val execution = project.xmakeExecutionService
-        execution.execute(console, commands.createConfigure())
-        execution.execute(
-            console,
-            commands.createRebuild(),
-            XMakeConsoleOptions(showProblems = true, showExitCode = true),
-        )
-    }
+    ): XMakeBuildTask = XMakeBuildTask(
+        presentableName = "Rebuild '${configuration.name}'",
+        commands = listOf(commands.createConfigure(), commands.createRebuild()),
+    )
 }

--- a/src/main/kotlin/io/xmake/actions/XMakeBuildAction.kt
+++ b/src/main/kotlin/io/xmake/actions/XMakeBuildAction.kt
@@ -1,0 +1,60 @@
+/*!A Xmake integration in IntelliJ IDEA/Clion
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (C) 2015-present, Xmake Open Source Community.
+ */
+package io.xmake.actions
+
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.project.Project
+import com.intellij.task.ProjectTaskManager
+import io.xmake.build.XMakeBuildTask
+import io.xmake.run.XMakeRunConfiguration
+import io.xmake.run.command.XMakeCommandFactory
+
+abstract class XMakeBuildAction : XMakeProjectAction() {
+    final override fun execute(project: Project) {
+        val configuration = project.selectedXMakeRunConfiguration
+        if (configuration == null) {
+            notifyConfigurationError(project, "Please select an XMake run configuration first")
+            return
+        }
+
+        val task = try {
+            configuration.checkConfiguration()
+            createTask(project, configuration, XMakeCommandFactory(configuration))
+        } catch (error: Exception) {
+            notifyConfigurationError(project, error.message ?: "The XMake configuration is invalid")
+            return
+        }
+
+        FileDocumentManager.getInstance().saveAllDocuments()
+        ProjectTaskManager.getInstance(project).run(task)
+    }
+
+    internal abstract fun createTask(
+        project: Project,
+        configuration: XMakeRunConfiguration,
+        commands: XMakeCommandFactory,
+    ): XMakeBuildTask
+}
+
+private fun notifyConfigurationError(project: Project, message: String) {
+    NotificationGroupManager.getInstance()
+        .getNotificationGroup("XMake.NotificationGroup")
+        .createNotification(message, NotificationType.ERROR)
+        .notify(project)
+}

--- a/src/main/kotlin/io/xmake/actions/XMakeCommandAction.kt
+++ b/src/main/kotlin/io/xmake/actions/XMakeCommandAction.kt
@@ -16,7 +16,6 @@
  */
 package io.xmake.actions
 
-import com.intellij.execution.RunManager
 import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
@@ -25,7 +24,6 @@ import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
 import io.xmake.project.console.XMakeConsole
 import io.xmake.project.console.xmakeConsoleService
-import io.xmake.run.XMakeRunConfiguration
 import io.xmake.run.command.XMakeCommandFactory
 import io.xmake.run.command.xmakeExecutionService
 import kotlinx.coroutines.Dispatchers
@@ -35,9 +33,7 @@ import java.util.concurrent.CancellationException
 abstract class XMakeCommandAction : XMakeProjectAction() {
 
     final override fun execute(project: Project) {
-        val configuration = RunManager.getInstance(project)
-            .selectedConfiguration
-            ?.configuration as? XMakeRunConfiguration
+        val configuration = project.selectedXMakeRunConfiguration
         val commandsResult = configuration?.let { runCatching { XMakeCommandFactory(it) } }
         FileDocumentManager.getInstance().saveAllDocuments()
 

--- a/src/main/kotlin/io/xmake/actions/XMakeRunConfigurationSelection.kt
+++ b/src/main/kotlin/io/xmake/actions/XMakeRunConfigurationSelection.kt
@@ -38,6 +38,9 @@ internal fun launchSelectedXMakeRunConfiguration(project: Project, executor: Exe
     ProgramRunnerUtil.executeConfiguration(settings, executor)
 }
 
+internal val Project.selectedXMakeRunConfiguration: XMakeRunConfiguration?
+    get() = selectedXMakeRunConfigurationSettings?.configuration as? XMakeRunConfiguration
+
 private val Project.selectedXMakeRunConfigurationSettings: RunnerAndConfigurationSettings?
     get() = RunManager.getInstance(this).selectedConfiguration
         ?.takeIf { it.configuration is XMakeRunConfiguration }

--- a/src/main/kotlin/io/xmake/build/XMakeBuildProcessHandler.kt
+++ b/src/main/kotlin/io/xmake/build/XMakeBuildProcessHandler.kt
@@ -1,0 +1,55 @@
+/*!A Xmake integration in IntelliJ IDEA/Clion
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (C) 2015-present, Xmake Open Source Community.
+ */
+package io.xmake.build
+
+import com.intellij.build.process.BuildProcessHandler
+import kotlinx.coroutines.Job
+import java.io.OutputStream
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+/** Exposes coroutine-backed XMake execution to the Build tool window. */
+internal class XMakeBuildProcessHandler(
+    private val executionName: String,
+) : BuildProcessHandler() {
+    private val cancellationRequested = AtomicBoolean()
+    private val executionJob = AtomicReference<Job?>()
+
+    override fun getExecutionName(): String = executionName
+
+    fun bind(job: Job) {
+        check(executionJob.compareAndSet(null, job))
+        if (cancellationRequested.get()) job.cancel()
+    }
+
+    fun finish(exitCode: Int) {
+        if (!isProcessTerminated) notifyProcessTerminated(exitCode)
+    }
+
+    override fun destroyProcessImpl() {
+        cancellationRequested.set(true)
+        executionJob.get()?.cancel()
+    }
+
+    override fun detachProcessImpl() {
+        notifyProcessDetached()
+    }
+
+    override fun detachIsDefault(): Boolean = false
+
+    override fun getProcessInput(): OutputStream? = null
+}

--- a/src/main/kotlin/io/xmake/build/XMakeBuildTask.kt
+++ b/src/main/kotlin/io/xmake/build/XMakeBuildTask.kt
@@ -1,0 +1,52 @@
+/*!A Xmake integration in IntelliJ IDEA/Clion
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (C) 2015-present, Xmake Open Source Community.
+ */
+package io.xmake.build
+
+import com.intellij.task.ProjectTask
+import io.xmake.run.command.XMakeCommand
+import io.xmake.run.command.XMAKE_CONFIG_DIRECTORY_ENV
+
+/** A platform build task whose commands already belong to one configuration. */
+internal class XMakeBuildTask(
+    private val presentableName: String,
+    commands: List<XMakeCommand>,
+) : ProjectTask {
+    val commands: List<XMakeCommand> = commands.toList()
+    val workingDirectory: String
+
+    init {
+        require(this.commands.isNotEmpty()) { "An XMake build task must contain at least one command" }
+        val firstCommand = this.commands.first()
+        require(firstCommand.configurationDirectory.isNotBlank()) {
+            "An XMake build task must carry an explicit XMake configuration directory"
+        }
+        require(this.commands.all { command -> command.hasSameExecutionContextAs(firstCommand) }) {
+            "All commands in an XMake build task must share one execution context"
+        }
+        workingDirectory = firstCommand.workingDirectory
+    }
+
+    override fun getPresentableName(): String = presentableName
+}
+
+private fun XMakeCommand.hasSameExecutionContextAs(other: XMakeCommand): Boolean =
+    toolkit === other.toolkit &&
+        workingDirectory == other.workingDirectory &&
+        configurationDirectory == other.configurationDirectory
+
+private val XMakeCommand.configurationDirectory: String
+    get() = commandLine.environment[XMAKE_CONFIG_DIRECTORY_ENV].orEmpty()

--- a/src/main/kotlin/io/xmake/build/XMakeProjectTaskRunner.kt
+++ b/src/main/kotlin/io/xmake/build/XMakeProjectTaskRunner.kt
@@ -1,0 +1,223 @@
+/*!A Xmake integration in IntelliJ IDEA/Clion
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (C) 2015-present, Xmake Open Source Community.
+ */
+package io.xmake.build
+
+import com.intellij.build.BuildViewManager
+import com.intellij.build.DefaultBuildDescriptor
+import com.intellij.build.FilePosition
+import com.intellij.build.events.MessageEvent
+import com.intellij.build.progress.BuildProgress
+import com.intellij.build.progress.BuildProgressDescriptor
+import com.intellij.execution.process.ProcessOutputType
+import com.intellij.openapi.progress.ProcessCanceledException
+import com.intellij.openapi.project.Project
+import com.intellij.task.ProjectTask
+import com.intellij.task.ProjectTaskContext
+import com.intellij.task.ProjectTaskRunner
+import io.xmake.run.command.XMakeCommandProcessHandler
+import io.xmake.run.command.XMakeConsoleOptions
+import io.xmake.run.command.xmakeExecutionService
+import io.xmake.shared.XMakeProblem
+import kotlinx.coroutines.CancellationException
+import org.jetbrains.concurrency.Promise
+import org.jetbrains.concurrency.toPromiseWithoutLogError
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+
+@Suppress("UnstableApiUsage")
+class XMakeProjectTaskRunner : ProjectTaskRunner() {
+    override fun canRun(
+        project: Project,
+        projectTask: ProjectTask,
+        context: ProjectTaskContext?,
+    ): Boolean = projectTask is XMakeBuildTask
+
+    override fun run(
+        project: Project,
+        context: ProjectTaskContext,
+        vararg tasks: ProjectTask,
+    ): Promise<Result> {
+        val buildTasks = tasks.map { task ->
+            require(task is XMakeBuildTask) { "Unsupported XMake project task: ${task.javaClass.name}" }
+            task
+        }
+        require(buildTasks.isNotEmpty()) { "No XMake project tasks were provided" }
+
+        val title = buildTasks.singleOrNull()?.getPresentableName() ?: "XMake Build"
+        val processHandler = XMakeBuildProcessHandler(title)
+        val progress = createBuildProgress(project, context, buildTasks, processHandler, title)
+        val completed = AtomicBoolean()
+        val operation = project.xmakeExecutionService.submit {
+            execute(project, buildTasks, progress, processHandler, completed, title)
+        }
+        val promise = operation.toPromiseWithoutLogError()
+        processHandler.bind(operation)
+        promise.onError { error ->
+            if (error is CancellationException) {
+                cancel(progress, processHandler, completed, title)
+            } else {
+                fail(progress, processHandler, completed, error, title)
+            }
+        }
+        return promise
+    }
+
+    private suspend fun execute(
+        project: Project,
+        tasks: List<XMakeBuildTask>,
+        progress: BuildProgress<BuildProgressDescriptor>,
+        processHandler: XMakeBuildProcessHandler,
+        completed: AtomicBoolean,
+        title: String,
+    ): Result = try {
+        for (task in tasks) {
+            for (command in task.commands) {
+                XMakeCommandProcessHandler(
+                    project,
+                    command,
+                    XMakeConsoleOptions(showProblems = true, preserveAnsiEscapes = true),
+                    onTextAvailable = { text, outputType ->
+                        progress.output(text, ProcessOutputType.fromKey(outputType))
+                    },
+                    onProblems = { problems ->
+                        progress.reportProblems(problems, command.toolkit.isOnRemote)
+                    },
+                ).awaitSuccessfulCompletion()
+            }
+        }
+
+        complete(processHandler, completed, SUCCESS_EXIT_CODE) {
+            progress.finish()
+        }
+        result()
+    } catch (error: CancellationException) {
+        cancel(progress, processHandler, completed, title)
+        throw error
+    } catch (error: ProcessCanceledException) {
+        cancel(progress, processHandler, completed, title)
+        throw error
+    } catch (error: Exception) {
+        fail(progress, processHandler, completed, error, title)
+        result(hasErrors = true)
+    }
+
+    private fun cancel(
+        progress: BuildProgress<BuildProgressDescriptor>,
+        processHandler: XMakeBuildProcessHandler,
+        completed: AtomicBoolean,
+        title: String,
+    ) {
+        complete(processHandler, completed, CANCELED_EXIT_CODE) {
+            progress.cancel(System.currentTimeMillis(), "$title was canceled")
+        }
+    }
+
+    private fun fail(
+        progress: BuildProgress<BuildProgressDescriptor>,
+        processHandler: XMakeBuildProcessHandler,
+        completed: AtomicBoolean,
+        error: Throwable,
+        title: String,
+    ) {
+        val message = error.message ?: "$title failed"
+        complete(processHandler, completed, FAILED_EXIT_CODE) {
+            progress.output("$message\n", ProcessOutputType.STDERR)
+            progress.fail(System.currentTimeMillis(), message)
+        }
+    }
+
+    private inline fun complete(
+        processHandler: XMakeBuildProcessHandler,
+        completed: AtomicBoolean,
+        exitCode: Int,
+        completion: () -> Unit,
+    ) {
+        if (!completed.compareAndSet(false, true)) return
+        try {
+            completion()
+        } finally {
+            processHandler.finish(exitCode)
+        }
+    }
+
+    private fun createBuildProgress(
+        project: Project,
+        context: ProjectTaskContext,
+        tasks: List<XMakeBuildTask>,
+        processHandler: XMakeBuildProcessHandler,
+        title: String,
+    ): BuildProgress<BuildProgressDescriptor> {
+        val descriptor = DefaultBuildDescriptor(
+            context.sessionId ?: UUID.randomUUID(),
+            title,
+            tasks.first().workingDirectory,
+            System.currentTimeMillis(),
+        ).apply {
+            isActivateToolWindowWhenAdded = context.runConfiguration == null
+            withProcessHandler(processHandler) { }
+        }
+        val progressDescriptor = object : BuildProgressDescriptor {
+            override fun getTitle(): String = descriptor.title
+            override fun getBuildDescriptor() = descriptor
+        }
+        return BuildViewManager.createBuildProgress(project).apply {
+            start(progressDescriptor)
+            processHandler.startNotify()
+        }
+    }
+
+    private fun BuildProgress<BuildProgressDescriptor>.reportProblems(
+        problems: List<XMakeProblem>,
+        remote: Boolean,
+    ) {
+        for (problem in problems) {
+            val kind = problem.messageKind()
+            val message = problem.message.orEmpty()
+            val position = problem.filePosition(remote)
+            if (position == null) {
+                message("XMake", message, kind, null)
+            } else {
+                fileMessage(position.path?.fileName?.toString() ?: "XMake", message, kind, position)
+            }
+        }
+    }
+
+    private fun XMakeProblem.filePosition(remote: Boolean): FilePosition? {
+        if (remote) return null
+        val resolvedPath = resolvedFilePath ?: return null
+        val sourceLine = line?.toIntOrNull()?.minus(1)?.coerceAtLeast(0) ?: 0
+        val sourceColumn = column?.toIntOrNull()?.minus(1)?.coerceAtLeast(0) ?: 0
+        return FilePosition(resolvedPath.normalize(), sourceLine, sourceColumn)
+    }
+
+    private fun XMakeProblem.messageKind(): MessageEvent.Kind = when {
+        kind?.contains("warning", ignoreCase = true) == true -> MessageEvent.Kind.WARNING
+        kind?.contains("note", ignoreCase = true) == true -> MessageEvent.Kind.INFO
+        else -> MessageEvent.Kind.ERROR
+    }
+
+    private fun result(hasErrors: Boolean = false): Result = object : Result {
+        override fun isAborted(): Boolean = false
+        override fun hasErrors(): Boolean = hasErrors
+    }
+
+    private companion object {
+        const val SUCCESS_EXIT_CODE = 0
+        const val FAILED_EXIT_CODE = 1
+        const val CANCELED_EXIT_CODE = 130
+    }
+}

--- a/src/main/kotlin/io/xmake/project/console/XMakeToolWindowProblemPanel.kt
+++ b/src/main/kotlin/io/xmake/project/console/XMakeToolWindowProblemPanel.kt
@@ -42,7 +42,6 @@ import io.xmake.shared.XMakeProblem
 import java.awt.Font
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
-import java.nio.file.InvalidPathException
 import java.nio.file.Path
 import javax.swing.JList
 import javax.swing.ListSelectionModel
@@ -171,17 +170,4 @@ class XMakeToolWindowProblemPanel(project: Project) : SimpleToolWindowPanel(fals
     }
 }
 
-internal fun resolveProblemPath(problem: XMakeProblem): Path? {
-    val file = problem.file ?: return null
-    val path = try {
-        Path.of(file)
-    } catch (_: InvalidPathException) {
-        return null
-    }
-
-    return if (path.isAbsolute) {
-        path.normalize()
-    } else {
-        problem.workingDirectory?.resolve(path)?.normalize()
-    }
-}
+internal fun resolveProblemPath(problem: XMakeProblem): Path? = problem.resolvedFilePath

--- a/src/main/kotlin/io/xmake/run/command/XMakeCommand.kt
+++ b/src/main/kotlin/io/xmake/run/command/XMakeCommand.kt
@@ -21,6 +21,8 @@ import com.intellij.openapi.project.Project
 import io.xmake.project.toolkit.Toolkit
 import io.xmake.utils.execute.createProcess
 
+internal const val XMAKE_CONFIG_DIRECTORY_ENV = "XMAKE_CONFIGDIR"
+
 /**
  * A prepared XMake invocation together with the host context that produced it.
  *

--- a/src/main/kotlin/io/xmake/run/command/XMakeCommandBuilder.kt
+++ b/src/main/kotlin/io/xmake/run/command/XMakeCommandBuilder.kt
@@ -101,7 +101,7 @@ internal class XMakeCommandBuilder private constructor(
             return XMakeCommandBuilder(
                 toolkit,
                 workingDirectory,
-                environmentOverrides = mapOf(XMAKE_CONFIG_DIRECTORY to configurationRoot),
+                environmentOverrides = mapOf(XMAKE_CONFIG_DIRECTORY_ENV to configurationRoot),
             )
         }
 
@@ -131,7 +131,5 @@ internal class XMakeCommandBuilder private constructor(
 
         private fun hostPath(parent: String, child: String): String =
             "${parent.trimEnd('/', '\\')}/$child"
-
-        private const val XMAKE_CONFIG_DIRECTORY = "XMAKE_CONFIGDIR"
     }
 }

--- a/src/main/kotlin/io/xmake/run/command/XMakeCommandProcessHandler.kt
+++ b/src/main/kotlin/io/xmake/run/command/XMakeCommandProcessHandler.kt
@@ -17,11 +17,14 @@
 package io.xmake.run.command
 
 import com.intellij.execution.ExecutionException
+import com.intellij.execution.process.AnsiEscapeDecoder
 import com.intellij.execution.process.KillableColoredProcessHandler
 import com.intellij.execution.process.ProcessEvent
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessListener
+import com.intellij.execution.process.KillableProcessHandler
 import com.intellij.execution.process.ProcessOutputType
+import com.intellij.execution.process.ProcessOutputTypes
 import com.intellij.execution.process.ProcessTerminatedListener
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
@@ -85,7 +88,11 @@ internal class XMakeCommandProcessHandler(
             throw ExecutionException("Failed to start XMake command: ${command.commandLine.commandLineString}", error)
         }
         return try {
-            val handler = KillableColoredProcessHandler(process, command.commandLine.commandLineString, Charsets.UTF_8)
+            val handler = if (options.preserveAnsiEscapes) {
+                KillableProcessHandler(process, command.commandLine.commandLineString, Charsets.UTF_8)
+            } else {
+                KillableColoredProcessHandler(process, command.commandLine.commandLineString, Charsets.UTF_8)
+            }
 
             handler.addProcessListener(object : ProcessListener {
                 override fun onTextAvailable(event: ProcessEvent, outputType: Key<*>) {
@@ -133,7 +140,11 @@ internal class XMakeCommandProcessHandler(
             null
         }
 
-        return output.split(LINE_BREAK_REGEX)
+        val plainOutput = StringBuilder()
+        AnsiEscapeDecoder().escapeText(output.toString(), ProcessOutputTypes.STDOUT) { text, _ ->
+            plainOutput.append(text)
+        }
+        return plainOutput.split(LINE_BREAK_REGEX)
             .mapNotNull { parseProblem(it.trim(), path) }
     }
 

--- a/src/main/kotlin/io/xmake/run/command/XMakeConsoleOptions.kt
+++ b/src/main/kotlin/io/xmake/run/command/XMakeConsoleOptions.kt
@@ -17,7 +17,7 @@
 package io.xmake.run.command
 
 /**
- * Controls how one XMake process is presented in the plugin console.
+ * Controls how one XMake process is presented to its output consumer.
  *
  * Command execution owns these flags instead of the action that started it.
  * This keeps Build, Clean, Run preparation, and debug preparation consistent
@@ -35,4 +35,6 @@ internal data class XMakeConsoleOptions(
     val showConsole: Boolean = true,
     val showProblems: Boolean = false,
     val showExitCode: Boolean = false,
+    /** Leaves ANSI escapes for a downstream console that performs its own decoding. */
+    val preserveAnsiEscapes: Boolean = false,
 )

--- a/src/main/kotlin/io/xmake/shared/XMakeProblem.kt
+++ b/src/main/kotlin/io/xmake/shared/XMakeProblem.kt
@@ -20,6 +20,7 @@
  */
 package io.xmake.shared
 
+import java.nio.file.InvalidPathException
 import java.nio.file.Path
 
 class XMakeProblem(
@@ -29,4 +30,20 @@ class XMakeProblem(
     val kind: String? = "error",
     val message: String? = "",
     val workingDirectory: Path? = null,
-)
+) {
+    internal val resolvedFilePath: Path?
+        get() {
+            val filePath = file?.takeIf(String::isNotBlank) ?: return null
+            val path = try {
+                Path.of(filePath)
+            } catch (_: InvalidPathException) {
+                return null
+            }
+
+            return if (path.isAbsolute) {
+                path.normalize()
+            } else {
+                workingDirectory?.resolve(path)?.normalize()
+            }
+        }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -45,6 +45,7 @@
         <programRunner implementation="io.xmake.run.XMakeRunner"/>
         <configurationType implementation="io.xmake.run.XMakeRunConfigurationType"/>
         <runConfigurationProducer implementation="io.xmake.run.XMakeRunConfigurationProducer"/>
+        <projectTaskRunner implementation="io.xmake.build.XMakeProjectTaskRunner"/>
 
         <!-- notifications -->
         <notificationGroup id="XMake.NotificationGroup" displayType="BALLOON"/>


### PR DESCRIPTION
**Integrated XMake builds with the platform Build tool window through ProjectTaskManager**

## _What Changed_
- Added `XMakeProjectTaskRunner` (`ProjectTaskRunner`) and registered it in `plugin.xml`, making XMake builds first-class platform build tasks.
- Added `XMakeBuildTask` and `XMakeBuildProcessHandler`: builds run as coroutines and report progress, output, and diagnostics to the Build tool window, with reliable cancellation.
- Added the `XMakeBuildAction` base class; Build, Clean, and Rebuild now validate the configuration and submit a `XMakeBuildTask` through `ProjectTaskManager` instead of spawning processes themselves.
- Diagnostics are reported as Build file messages with file/line/column positions (plain messages for remote builds), so problems are clickable and navigate to the exact source location.

## _Why_
- ***The Build tool window is the standard place for builds.*** Builds previously ran through hand-rolled process handling in the console — no Build tool window integration, no cancellation, and no error navigation. `ProjectTaskManager` is the platform's canonical build mechanism and provides progress, output, cancellation, and problem reporting as first-class features.
- ***Long builds must be cancellable and observable.*** A running xmake build could neither be stopped reliably nor inspected in the IDE's own build view. The coroutine-backed handler binds cancellation to the platform Stop action and streams output in real time.
- ***Diagnostics belong in the IDE, not just in text.*** Compiler warnings and errors are now parsed into Build messages with positions, so clicking one opens the file at the right line — consistent with the navigation users already get from the Problems tool window.
- ***Build, Clean, and Rebuild should share one path.*** The three actions now go through a single `XMakeBuildAction` + `ProjectTaskManager` flow, removing duplicated process code and guaranteeing identical behavior.

## _Impact_
*Build, Clean, and Rebuild now run in the Build tool window with progress, reliable cancellation, and clickable diagnostics — through the platform's standard task mechanism.*
