### PR TITLE
Add XMake build profile management UI

### DIFF
--- a/src/main/kotlin/io/xmake/actions/BuildAction.kt
+++ b/src/main/kotlin/io/xmake/actions/BuildAction.kt
@@ -26,7 +26,7 @@ import io.xmake.project.profile.XMakeBuildProfile
 import io.xmake.project.xmakeSettings
 import io.xmake.run.command.XMakeCommandFactory
 
-class BuildAction : XMakeBuildAction() {
+open class BuildAction : XMakeBuildAction() {
 
     override fun createTask(
         project: Project,

--- a/src/main/kotlin/io/xmake/actions/EditXMakeBuildProfilesAction.kt
+++ b/src/main/kotlin/io/xmake/actions/EditXMakeBuildProfilesAction.kt
@@ -1,0 +1,41 @@
+/*!A Xmake integration in IntelliJ IDEA/Clion
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (C) 2015-present, Xmake Open Source Community.
+ */
+package io.xmake.actions
+
+import com.intellij.execution.actions.EXECUTION_TARGETS_COMBO_ACTION_PLACE
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.Project
+import io.xmake.project.profile.ui.XMakeBuildProfilesDialog
+import io.xmake.run.target.activeOrSingleXMakeBuildProfile
+
+class EditXMakeBuildProfilesAction : XMakeProjectAction() {
+    override fun update(e: AnActionEvent) {
+        super.update(e)
+        if (!e.presentation.isVisible) return
+
+        e.presentation.icon = if (e.place == EXECUTION_TARGETS_COMBO_ACTION_PLACE) {
+            null
+        } else {
+            AllIcons.General.Settings
+        }
+    }
+
+    override fun execute(project: Project) {
+        XMakeBuildProfilesDialog(project, project.activeOrSingleXMakeBuildProfile?.id).show()
+    }
+}

--- a/src/main/kotlin/io/xmake/actions/RunToolbarBuildAction.kt
+++ b/src/main/kotlin/io/xmake/actions/RunToolbarBuildAction.kt
@@ -1,0 +1,32 @@
+/*!A Xmake integration in IntelliJ IDEA/Clion
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (C) 2015-present, Xmake Open Source Community.
+ */
+package io.xmake.actions
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import io.xmake.run.target.activeOrSingleXMakeBuildProfile
+
+class RunToolbarBuildAction : BuildAction() {
+    override fun update(e: AnActionEvent) {
+        super.update(e)
+        if (!e.presentation.isEnabledAndVisible) return
+
+        val project = e.project ?: return
+        val profile = project.activeOrSingleXMakeBuildProfile
+        e.presentation.isEnabledAndVisible =
+            project.selectedXMakeRunConfiguration != null && profile?.canExecute(project) == true
+    }
+}

--- a/src/main/kotlin/io/xmake/project/directory/ToolkitProjectDirectory.kt
+++ b/src/main/kotlin/io/xmake/project/directory/ToolkitProjectDirectory.kt
@@ -1,0 +1,35 @@
+/*!A Xmake integration in IntelliJ IDEA/Clion
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (C) 2015-present, Xmake Open Source Community.
+ */
+package io.xmake.project.directory
+
+import com.intellij.openapi.project.Project
+import io.xmake.project.toolkit.Toolkit
+import io.xmake.project.toolkit.ToolkitHostType.LOCAL
+import io.xmake.project.toolkit.ToolkitHostType.SSH
+import io.xmake.project.toolkit.ToolkitHostType.WSL
+import io.xmake.utils.extension.ToolkitHostExtension
+import io.xmake.utils.path.WorkingDirectoryResolver
+
+internal suspend fun Toolkit.resolveDefaultWorkingDirectory(project: Project): String? = when (host.type) {
+    LOCAL -> project.basePath
+    WSL -> {
+        val distribution = host.wslDistribution ?: return null
+        project.basePath?.let { path -> WorkingDirectoryResolver.resolveForWsl(project, path, distribution) }
+    }
+    SSH -> ToolkitHostExtension.forHostType(SSH)
+        ?.resolveDefaultWorkingDirectory(project, host)
+}

--- a/src/main/kotlin/io/xmake/project/profile/XMakeBuildProfileOptions.kt
+++ b/src/main/kotlin/io/xmake/project/profile/XMakeBuildProfileOptions.kt
@@ -1,0 +1,53 @@
+/*!A Xmake integration in IntelliJ IDEA/Clion
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (C) 2015-present, Xmake Open Source Community.
+ */
+package io.xmake.project.profile
+
+import com.intellij.openapi.project.Project
+import io.xmake.run.command.configureBestEffort
+import io.xmake.run.command.executeInfoQuery
+import io.xmake.run.command.withProfileCommands
+import io.xmake.utils.info.XMakeInfo
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+internal data class XMakeBuildProfileOptions(
+    val architectures: Map<String, List<String>> = emptyMap(),
+    val buildModes: List<String> = emptyList(),
+    val platforms: List<String> = emptyList(),
+    val toolchains: Map<String, String> = emptyMap(),
+)
+
+/** Queries the XMake option choices available in one build profile's command context. */
+internal suspend fun Project.queryXMakeBuildProfileOptions(
+    profile: XMakeBuildProfile,
+): XMakeBuildProfileOptions {
+    xmakeBuildProfileOptionsCache.get(profile)?.let { return it }
+    val options = withContext(Dispatchers.IO) {
+        withProfileCommands(profile) { executionService ->
+            configureBestEffort(executionService)
+            val parser = XMakeInfo()
+            XMakeBuildProfileOptions(
+                architectures = parser.parseArchitectures(executeInfoQuery("architectures", executionService)),
+                buildModes = parser.parseBuildModes(executeInfoQuery("buildmodes", executionService)),
+                platforms = parser.parsePlatforms(executeInfoQuery("platforms", executionService)),
+                toolchains = parser.parseToolchains(executeInfoQuery("toolchains", executionService)),
+            )
+        }
+    }
+    xmakeBuildProfileOptionsCache.put(profile, options)
+    return options
+}

--- a/src/main/kotlin/io/xmake/project/profile/XMakeBuildProfileOptionsCache.kt
+++ b/src/main/kotlin/io/xmake/project/profile/XMakeBuildProfileOptionsCache.kt
@@ -1,0 +1,49 @@
+/*!A Xmake integration in IntelliJ IDEA/Clion
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (C) 2015-present, Xmake Open Source Community.
+ */
+package io.xmake.project.profile
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+
+/** Recent per-profile option snapshots so reopened editors do not re-run XMake queries. */
+@Service(Service.Level.PROJECT)
+internal class XMakeBuildProfileOptionsCache {
+    private val lock = Any()
+    private val entries = object : LinkedHashMap<XMakeBuildProfile, XMakeBuildProfileOptions>() {
+        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<XMakeBuildProfile, XMakeBuildProfileOptions>) =
+            size > MAX_ENTRIES
+    }
+
+    fun get(profile: XMakeBuildProfile): XMakeBuildProfileOptions? = synchronized(lock) { entries[profile] }
+
+    fun put(profile: XMakeBuildProfile, options: XMakeBuildProfileOptions) {
+        synchronized(lock) {
+            entries.remove(profile)
+            entries[profile] = options
+        }
+    }
+
+    fun clear() = synchronized(lock) { entries.clear() }
+
+    private companion object {
+        const val MAX_ENTRIES = 8
+    }
+}
+
+internal val Project.xmakeBuildProfileOptionsCache: XMakeBuildProfileOptionsCache
+    get() = getService(XMakeBuildProfileOptionsCache::class.java)
+        ?: error("Failed to get XMakeBuildProfileOptionsCache for $this")

--- a/src/main/kotlin/io/xmake/project/profile/ui/XMakeBuildProfileEditor.kt
+++ b/src/main/kotlin/io/xmake/project/profile/ui/XMakeBuildProfileEditor.kt
@@ -1,0 +1,94 @@
+/*!A Xmake integration in IntelliJ IDEA/Clion
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (C) 2015-present, Xmake Open Source Community.
+ */
+package io.xmake.project.profile.ui
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ui.componentsList.components.ScrollablePanel
+import com.intellij.openapi.ui.NamedConfigurable
+import com.intellij.openapi.util.Disposer
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.util.ui.JBUI
+import io.xmake.icons.XMakeIcons
+import io.xmake.project.profile.XMakeBuildProfile
+import java.awt.BorderLayout
+import java.awt.Dimension
+import javax.swing.Icon
+import javax.swing.JComponent
+
+internal class XMakeBuildProfileEditor(
+    project: Project,
+    initialProfile: XMakeBuildProfile,
+    private val treeUpdater: Runnable,
+) : NamedConfigurable<XMakeBuildProfile>(true, treeUpdater) {
+    private val form = XMakeBuildProfileForm(project)
+    private var appliedProfile = initialProfile.copy()
+    private var profileName = appliedProfile.name
+
+    init {
+        form.reset(appliedProfile)
+    }
+
+    val profile: XMakeBuildProfile
+        get() = appliedProfile.copy()
+
+    override fun getDisplayName(): String = profileName
+
+    override fun setDisplayName(value: String) {
+        profileName = value
+        treeUpdater.run()
+    }
+
+    override fun getBannerSlogan(): String = "XMake build profile: $displayName"
+
+    override fun getEditableObject(): XMakeBuildProfile = profile
+
+    override fun getIcon(expanded: Boolean): Icon = XMakeIcons.XMAKE
+
+    override fun createOptionsPanel(): JComponent {
+        val content = ScrollablePanel(BorderLayout()).apply {
+            add(form.component, BorderLayout.CENTER)
+        }
+        return object : JBScrollPane(content) {
+            init {
+                border = JBUI.Borders.empty()
+            }
+
+            override fun getMinimumSize(): Dimension = Dimension(
+                content.minimumSize.width,
+                super.minimumSize.height,
+            )
+        }
+    }
+
+    override fun isModified(): Boolean = form.createProfileSnapshot(profileName) != appliedProfile
+
+    override fun apply() {
+        profileName = profileName.trim()
+        appliedProfile = form.createProfileSnapshot(profileName)
+        treeUpdater.run()
+    }
+
+    override fun reset() {
+        profileName = appliedProfile.name
+        form.reset(appliedProfile)
+    }
+
+    override fun disposeUIResources() {
+        Disposer.dispose(form)
+        super.disposeUIResources()
+    }
+}

--- a/src/main/kotlin/io/xmake/project/profile/ui/XMakeBuildProfileForm.kt
+++ b/src/main/kotlin/io/xmake/project/profile/ui/XMakeBuildProfileForm.kt
@@ -1,0 +1,465 @@
+/*!A Xmake integration in IntelliJ IDEA/Clion
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (C) 2015-present, Xmake Open Source Community.
+ */
+package io.xmake.project.profile.ui
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.EDT
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.application.asContextElement
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+import com.intellij.openapi.util.Disposer
+import com.intellij.platform.ide.progress.withBackgroundProgress
+import com.intellij.ui.DocumentAdapter
+import com.intellij.ui.RawCommandLineEditor
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.dsl.builder.AlignX
+import com.intellij.ui.dsl.builder.AlignY
+import com.intellij.ui.dsl.builder.IntelliJSpacingConfiguration
+import com.intellij.ui.dsl.builder.RowLayout
+import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.dsl.gridLayout.toJBEmptyBorder
+import com.intellij.ui.layout.ComboBoxPredicate
+import io.xmake.project.directory.resolveDefaultWorkingDirectory
+import io.xmake.project.directory.ui.DirectoryBrowser
+import io.xmake.project.profile.XMakeBuildProfile
+import io.xmake.project.profile.XMakeBuildProfileOptions
+import io.xmake.project.profile.queryXMakeBuildProfileOptions
+import io.xmake.project.toolkit.ToolkitHost.Id
+import io.xmake.project.toolkit.Toolkit
+import io.xmake.project.toolkit.ui.ToolkitComboBox
+import io.xmake.project.toolkit.ui.ToolkitListItem
+import io.xmake.utils.execute.SyncDirection
+import io.xmake.utils.execute.transferProjectFiles
+import io.xmake.utils.path.WorkingDirectoryResolver
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.transformLatest
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.awt.event.HierarchyEvent
+import java.awt.event.HierarchyListener
+import java.awt.event.ItemEvent
+import javax.swing.JComponent
+import javax.swing.event.DocumentEvent
+
+private data class OptionRequest(
+    val profile: XMakeBuildProfile,
+    val debounceMillis: Long,
+)
+
+@OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
+internal class XMakeBuildProfileForm(
+    private val project: Project,
+) : Disposable {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private var baselineProfile = XMakeBuildProfile()
+    private var selectedToolkit: Toolkit? = null
+    private var workingDirectoryHostId: Id? = null
+    private var isDefaultWorkingDirectoryPending = false
+    private var profileOptions = XMakeBuildProfileOptions()
+    private var loadedOptionsProfile: XMakeBuildProfile? = null
+    private var optionToolkitId: String? = null
+    private val optionRequests = Channel<OptionRequest>(Channel.CONFLATED)
+    private val workingDirectoryRequests = Channel<Toolkit>(Channel.CONFLATED)
+    private var isResetting = false
+    private var isUpdatingOptions = false
+
+    private val toolkitComboBox = ToolkitComboBox(project, ::selectedToolkit)
+    private val platformComboBox = XMakeBuildProfileOptionComboBox()
+    private val architectureComboBox = XMakeBuildProfileOptionComboBox()
+    private val toolchainComboBox = XMakeBuildProfileOptionComboBox()
+    private val buildModeComboBox = XMakeBuildProfileOptionComboBox()
+    private val workingDirectory = DirectoryBrowser(
+        project,
+        browseTitle = "Working Directory",
+        browseDescription = "Select the working directory",
+    )
+    private val buildDirectory = DirectoryBrowser(
+        project,
+        browseTitle = "Build Directory",
+        browseDescription = "Select the build directory",
+    )
+    private val androidNdkDirectory = DirectoryBrowser(
+        project,
+        browseTitle = "Android NDK Directory",
+        browseDescription = "Select the Android NDK directory",
+    )
+    private val verbose = JBCheckBox("Enable verbose output")
+    private val configureArguments = RawCommandLineEditor()
+
+    val component: JComponent = panel {
+        row("XMake toolkit:") {
+            cell(toolkitComboBox).align(AlignX.FILL)
+        }
+
+        row {
+            label("Configuration:").align(AlignY.TOP)
+            panel {
+                row { label("Platform:") }
+                row { cell(platformComboBox).align(AlignX.FILL) }
+            }.resizableColumn()
+            panel {
+                row { label("Architecture:") }
+                row { cell(architectureComboBox).align(AlignX.FILL) }
+            }.resizableColumn()
+            panel {
+                row { label("Toolchain:") }
+                row { cell(toolchainComboBox).align(AlignX.FILL) }
+            }.resizableColumn()
+        }.layout(RowLayout.PARENT_GRID)
+
+        separator()
+
+        row("Build mode:") {
+            cell(buildModeComboBox).align(AlignX.FILL)
+        }
+
+        collapsibleGroup("Additional Configuration") {
+            row("Working directory:") {
+                cell(workingDirectory).align(AlignX.FILL)
+            }
+            row("Build directory:") {
+                cell(buildDirectory).align(AlignX.FILL)
+            }
+            row("Android NDK directory:") {
+                cell(androidNdkDirectory).align(AlignX.FILL)
+            }
+            row("Additional options:") {
+                cell(configureArguments).align(AlignX.FILL)
+            }
+            row {
+                cell(verbose)
+            }
+        }
+
+        row("Project files:") {
+            button("Upload") {
+                startFileTransfer(SyncDirection.LOCAL_TO_REMOTE)
+            }
+            button("Download") {
+                startFileTransfer(SyncDirection.REMOTE_TO_LOCAL)
+            }
+        }.visibleIf(ComboBoxPredicate<ToolkitListItem>(toolkitComboBox) { item ->
+            (item as? ToolkitListItem.Entry)?.toolkit?.requiresBackend == true
+        })
+    }.apply {
+        border = IntelliJSpacingConfiguration().dialogUnscaledGaps.toJBEmptyBorder()
+    }
+
+    private val profileOptionsVisibilityListener = HierarchyListener { event ->
+        if ((event.changeFlags and HierarchyEvent.SHOWING_CHANGED.toLong()) == 0L) {
+            return@HierarchyListener
+        }
+        if (component.isShowing) onFormShown()
+    }
+
+    init {
+        scope.launch {
+            optionRequests.consumeAsFlow()
+                .debounce { request -> request.debounceMillis }
+                .transformLatest { request ->
+                    val options = try {
+                        project.queryXMakeBuildProfileOptions(request.profile)
+                    } catch (error: CancellationException) {
+                        throw error
+                    } catch (error: Exception) {
+                        Log.debug("Unable to load XMake build profile options", error)
+                        null
+                    }
+                    emit(request to options)
+                }
+                .collect { (request, options) ->
+                    withContext(Dispatchers.EDT + ModalityState.any().asContextElement()) {
+                        options?.let { applyProfileOptions(request, it) }
+                    }
+                }
+        }
+        scope.launch {
+            workingDirectoryRequests.consumeAsFlow()
+                .transformLatest { toolkit ->
+                    val directory = try {
+                        toolkit.resolveDefaultWorkingDirectory(project)
+                    } catch (error: CancellationException) {
+                        throw error
+                    } catch (error: Exception) {
+                        Log.debug("Unable to load the default XMake working directory", error)
+                        null
+                    }
+                    emit(toolkit to directory)
+                }
+                .collect { (toolkit, directory) ->
+                    withContext(Dispatchers.EDT + ModalityState.any().asContextElement()) {
+                        applyDefaultWorkingDirectory(toolkit, directory)
+                    }
+                }
+        }
+        Disposer.register(this, toolkitComboBox)
+        toolkitComboBox.addSelectionListener { selectedToolkit ->
+            if (!isResetting) onToolkitSelected(selectedToolkit)
+        }
+        platformComboBox.addItemListener { event ->
+            if (
+                event.stateChange == ItemEvent.SELECTED &&
+                !isResetting &&
+                !isUpdatingOptions
+            ) {
+                updateArchitectureOptions()
+            }
+        }
+        workingDirectory.textField.document.addDocumentListener(object : DocumentAdapter() {
+            override fun textChanged(event: DocumentEvent) {
+                if (!isResetting) requestProfileOptions(PROFILE_OPTIONS_RELOAD_DELAY_MS)
+            }
+        })
+        component.addHierarchyListener(profileOptionsVisibilityListener)
+    }
+
+    fun reset(profile: XMakeBuildProfile) {
+        profileOptions = XMakeBuildProfileOptions()
+        loadedOptionsProfile = null
+        baselineProfile = profile.copy()
+        isResetting = true
+        try {
+            selectedToolkit = profile.resolveToolkit(project)
+            optionToolkitId = selectedToolkit?.id
+            workingDirectoryHostId = selectedToolkit?.host?.id
+            workingDirectory.text = profile.workingDirectory
+            buildDirectory.text = profile.buildDirectory
+            androidNdkDirectory.text = profile.androidNdkDirectory
+            verbose.isSelected = profile.verbose
+            configureArguments.text = profile.configureArguments
+
+            platformComboBox.updateOptions(emptyList(), profile.platform)
+            architectureComboBox.updateOptions(emptyList(), profile.architecture)
+            toolchainComboBox.updateOptions(emptyList(), profile.toolchain)
+            buildModeComboBox.updateOptions(
+                listOf(XMakeBuildProfile.DEFAULT_BUILD_MODE, "debug"),
+                profile.buildMode,
+                fallback = XMakeBuildProfile.DEFAULT_BUILD_MODE,
+            )
+            toolkitComboBox.selectToolkit(selectedToolkit)
+            rebindDirectoryBrowsers()
+            isDefaultWorkingDirectoryPending = selectedToolkit != null && workingDirectory.text.isBlank()
+        } finally {
+            isResetting = false
+        }
+        if (component.isShowing) onFormShown()
+    }
+
+    fun createProfileSnapshot(name: String): XMakeBuildProfile = baselineProfile.copy(
+        name = name,
+        toolkitId = selectedToolkit?.id,
+        platform = platformComboBox.selectedItem?.toString() ?: XMakeBuildProfile.USE_XMAKE_DEFAULT,
+        architecture = architectureComboBox.selectedItem?.toString() ?: XMakeBuildProfile.USE_XMAKE_DEFAULT,
+        toolchain = toolchainComboBox.selectedItem?.toString() ?: XMakeBuildProfile.USE_XMAKE_DEFAULT,
+        buildMode = buildModeComboBox.selectedItem?.toString() ?: XMakeBuildProfile.DEFAULT_BUILD_MODE,
+        workingDirectory = workingDirectory.text,
+        buildDirectory = buildDirectory.text,
+        androidNdkDirectory = androidNdkDirectory.text,
+        verbose = verbose.isSelected,
+        configureArguments = configureArguments.text,
+    )
+
+    override fun dispose() {
+        component.removeHierarchyListener(profileOptionsVisibilityListener)
+        scope.cancel()
+    }
+
+    private fun onToolkitSelected(selectedToolkit: Toolkit?) {
+        rebindDirectoryBrowsers()
+        val toolkitId = selectedToolkit?.id
+        if (toolkitId == optionToolkitId) {
+            if (selectedToolkit != null && workingDirectory.text.isBlank()) {
+                requestDefaultWorkingDirectory(selectedToolkit)
+            }
+            return
+        }
+        optionToolkitId = toolkitId
+        profileOptions = XMakeBuildProfileOptions()
+        updateOptionModels()
+
+        if (selectedToolkit == null) {
+            workingDirectoryHostId = null
+            isDefaultWorkingDirectoryPending = false
+            return
+        }
+
+        val hostId = selectedToolkit.host.id
+        if (workingDirectoryHostId != hostId) {
+            workingDirectoryHostId = hostId
+            workingDirectory.text = ""
+        }
+
+        if (workingDirectory.text.isBlank()) {
+            requestDefaultWorkingDirectory(selectedToolkit)
+        } else {
+            requestProfileOptions()
+        }
+    }
+
+    private fun rebindDirectoryBrowsers() {
+        listOf(workingDirectory, buildDirectory, androidNdkDirectory).forEach { browser ->
+            browser.setToolkit(selectedToolkit)
+        }
+    }
+
+    private fun onFormShown() {
+        val toolkit = selectedToolkit
+        if (isDefaultWorkingDirectoryPending && toolkit != null) {
+            isDefaultWorkingDirectoryPending = false
+            requestDefaultWorkingDirectory(toolkit)
+        }
+        requestProfileOptions()
+    }
+
+    private fun requestProfileOptions(debounceMillis: Long = 0) {
+        if (!component.isShowing) return
+
+        val toolkit = selectedToolkit
+        val requestedProfile = toolkit?.let(::profileForOptionQuery)
+        if (requestedProfile == null) {
+            profileOptions = XMakeBuildProfileOptions()
+            updateOptionModels()
+            return
+        }
+        if (loadedOptionsProfile == requestedProfile) return
+
+        optionRequests.trySend(OptionRequest(requestedProfile, debounceMillis))
+    }
+
+    private fun applyProfileOptions(request: OptionRequest, options: XMakeBuildProfileOptions) {
+        if (project.isDisposed || !component.isShowing) return
+        if (profileForOptionQuery(selectedToolkit ?: return) != request.profile) return
+        profileOptions = options
+        loadedOptionsProfile = request.profile
+        updateOptionModels()
+    }
+
+    private fun profileForOptionQuery(selectedToolkit: Toolkit): XMakeBuildProfile? {
+        if (
+            !selectedToolkit.isAvailable ||
+            selectedToolkit.path.isBlank() ||
+            selectedToolkit.requiresBackend && !selectedToolkit.host.hasBackend ||
+            workingDirectory.text.isBlank()
+        ) {
+            return null
+        }
+        return createProfileSnapshot(baselineProfile.name)
+    }
+
+    private fun updateOptionModels() {
+        isUpdatingOptions = true
+        try {
+            platformComboBox.updateOptions(
+                profileOptions.platforms + profileOptions.architectures.keys,
+                platformComboBox.selectedItem?.toString(),
+            )
+            val platform = platformComboBox.selectedItem?.toString() ?: XMakeBuildProfile.USE_XMAKE_DEFAULT
+            architectureComboBox.updateOptions(
+                profileOptions.architectures[platform].orEmpty(),
+                architectureComboBox.selectedItem?.toString(),
+            )
+            toolchainComboBox.updateOptions(
+                profileOptions.toolchains.keys,
+                toolchainComboBox.selectedItem?.toString(),
+            )
+            buildModeComboBox.updateOptions(
+                profileOptions.buildModes
+                    .map { mode -> mode.removePrefix("mode.") }
+                    .ifEmpty { listOf(XMakeBuildProfile.DEFAULT_BUILD_MODE, "debug") },
+                buildModeComboBox.selectedItem?.toString(),
+                fallback = XMakeBuildProfile.DEFAULT_BUILD_MODE,
+            )
+        } finally {
+            isUpdatingOptions = false
+        }
+    }
+
+    private fun updateArchitectureOptions() {
+        val platform = platformComboBox.selectedItem?.toString() ?: XMakeBuildProfile.USE_XMAKE_DEFAULT
+        val architectures = profileOptions.architectures[platform].orEmpty()
+        val currentArchitecture = architectureComboBox.selectedItem?.toString()
+        val selectedArchitecture = when {
+            currentArchitecture in architectures -> currentArchitecture
+            baselineProfile.architecture in architectures -> baselineProfile.architecture
+            architectures.isNotEmpty() -> architectures.first()
+            else -> XMakeBuildProfile.USE_XMAKE_DEFAULT
+        }
+        architectureComboBox.updateOptions(architectures, selectedArchitecture)
+    }
+
+    private fun requestDefaultWorkingDirectory(toolkit: Toolkit) {
+        if (component.isShowing) {
+            workingDirectoryRequests.trySend(toolkit)
+        } else {
+            isDefaultWorkingDirectoryPending = true
+        }
+    }
+
+    private fun applyDefaultWorkingDirectory(toolkit: Toolkit, directory: String?) {
+        if (project.isDisposed || !component.isShowing) return
+        if (selectedToolkit?.host?.id != toolkit.host.id) return
+        if (workingDirectory.text.isNotBlank()) return
+        if (directory.isNullOrBlank()) {
+            isDefaultWorkingDirectoryPending = true
+        } else {
+            isDefaultWorkingDirectoryPending = false
+            workingDirectory.text = directory
+        }
+    }
+
+    private fun startFileTransfer(direction: SyncDirection) {
+        val toolkit = selectedToolkit ?: return
+        val directory = workingDirectory.text
+        scope.launch {
+            try {
+                withBackgroundProgress(project, "Transfer XMake project files", cancellable = true) {
+                    val resolvedDirectory = WorkingDirectoryResolver.resolve(project, directory, toolkit)
+                    transferProjectFiles(project, toolkit, direction, resolvedDirectory)
+                }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                Log.warn("Unable to transfer XMake project files", error)
+                withContext(Dispatchers.EDT + ModalityState.any().asContextElement()) {
+                    if (!project.isDisposed) {
+                        Messages.showErrorDialog(
+                            project,
+                            error.message ?: "Unable to transfer XMake project files",
+                            "XMake Project File Transfer",
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private companion object {
+        const val PROFILE_OPTIONS_RELOAD_DELAY_MS = 300L
+        val Log = logger<XMakeBuildProfileForm>()
+    }
+}

--- a/src/main/kotlin/io/xmake/project/profile/ui/XMakeBuildProfileOptionComboBox.kt
+++ b/src/main/kotlin/io/xmake/project/profile/ui/XMakeBuildProfileOptionComboBox.kt
@@ -1,0 +1,63 @@
+/*!A Xmake integration in IntelliJ IDEA/Clion
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (C) 2015-present, Xmake Open Source Community.
+ */
+package io.xmake.project.profile.ui
+
+import com.intellij.ui.MutableCollectionComboBoxModel
+import io.xmake.project.profile.XMakeBuildProfile
+import io.xmake.utils.ui.LiveModelComboBox
+
+internal class XMakeBuildProfileOptionComboBox : LiveModelComboBox<String>(MutableCollectionComboBoxModel()) {
+    private val optionModel: MutableCollectionComboBoxModel<String>
+        get() = model as MutableCollectionComboBoxModel<String>
+
+    init {
+        maximumRowCount = 30
+    }
+
+    fun updateOptions(
+        values: Iterable<String>,
+        selectedValue: String?,
+        fallback: String = XMakeBuildProfile.USE_XMAKE_DEFAULT,
+    ) {
+        val currentValue = selectedValue.orEmpty().ifBlank { fallback }
+        val options = buildList {
+            add(fallback)
+            addAll(values.filter(String::isNotBlank))
+            if (currentValue !in this) add(currentValue)
+        }.distinct()
+
+        synchronizeOptions(options)
+        if (selectedItem != currentValue) selectedItem = currentValue
+        refreshPopupFromModel()
+    }
+
+    private fun synchronizeOptions(options: List<String>) {
+        val commonSize = minOf(optionModel.size, options.size)
+        for (index in 0 until commonSize) {
+            if (optionModel.getElementAt(index) != options[index]) {
+                optionModel.setElementAt(options[index], index)
+            }
+        }
+        when {
+            optionModel.size > options.size ->
+                // IntelliJ's removeRange is inclusive on both ends, so this removes the tail after `options`.
+                optionModel.removeRange(options.size, optionModel.size - 1)
+            optionModel.size < options.size ->
+                optionModel.add(options.drop(optionModel.size))
+        }
+    }
+}

--- a/src/main/kotlin/io/xmake/project/profile/ui/XMakeBuildProfilesDialog.kt
+++ b/src/main/kotlin/io/xmake/project/profile/ui/XMakeBuildProfilesDialog.kt
@@ -1,0 +1,66 @@
+/*!A Xmake integration in IntelliJ IDEA/Clion
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (C) 2015-present, Xmake Open Source Community.
+ */
+package io.xmake.project.profile.ui
+
+import com.intellij.openapi.options.ConfigurationException
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.ui.ValidationInfo
+import com.intellij.util.ui.JBUI
+import java.awt.Dimension
+import javax.swing.JComponent
+
+internal class XMakeBuildProfilesDialog(
+    project: Project,
+    preselectedProfileId: String?,
+) : DialogWrapper(project) {
+    private val editor = XMakeBuildProfilesEditor(project, preselectedProfileId)
+
+    init {
+        title = "XMake Build Profiles"
+        init()
+    }
+
+    override fun createCenterPanel(): JComponent = editor.component
+
+    override fun getPreferredFocusedComponent(): JComponent = editor.tree
+
+    override fun getDimensionServiceKey(): String = DIMENSION_KEY
+
+    override fun getInitialSize(): Dimension = JBUI.size(980, 660)
+
+    override fun doValidate(): ValidationInfo? = editor.validateProfiles()
+
+    override fun doOKAction() {
+        try {
+            editor.applyChanges()
+        } catch (error: ConfigurationException) {
+            setErrorText(error.localizedMessage)
+            return
+        }
+        super.doOKAction()
+    }
+
+    override fun dispose() {
+        editor.disposeUIResources()
+        super.dispose()
+    }
+
+    private companion object {
+        const val DIMENSION_KEY = "XMake.BuildProfilesDialog"
+    }
+}

--- a/src/main/kotlin/io/xmake/project/profile/ui/XMakeBuildProfilesEditor.kt
+++ b/src/main/kotlin/io/xmake/project/profile/ui/XMakeBuildProfilesEditor.kt
@@ -1,0 +1,128 @@
+/*!A Xmake integration in IntelliJ IDEA/Clion
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (C) 2015-present, Xmake Open Source Community.
+ */
+package io.xmake.project.profile.ui
+
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.options.ConfigurationException
+import com.intellij.openapi.project.DumbAwareAction
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.MasterDetailsComponent
+import com.intellij.openapi.ui.ValidationInfo
+import io.xmake.project.profile.XMakeBuildProfile
+import io.xmake.project.profile.xmakeBuildProfiles
+import javax.swing.JComponent
+import javax.swing.tree.DefaultTreeModel
+
+internal class XMakeBuildProfilesEditor(
+    private val project: Project,
+    private val preselectedProfileId: String?,
+) : MasterDetailsComponent() {
+    init {
+        initTree()
+    }
+
+    val component: JComponent = createComponent()
+
+    init {
+        reset()
+    }
+
+    override fun getDisplayName(): String = "Build Profiles"
+
+    override fun getEmptySelectionString(): String = "Select an XMake build profile"
+
+    override fun isModified(): Boolean =
+        super.isModified() || project.xmakeBuildProfiles.profiles != profileEditors().map { it.profile }
+
+    override fun reset() {
+        disposeCurrentEditors()
+        clearChildren()
+        project.xmakeBuildProfiles.profiles.forEach { profile ->
+            val editor = XMakeBuildProfileEditor(project, profile, TREE_UPDATER)
+            myRoot.add(MyNode(editor))
+        }
+        super.reset()
+        preselectProfile(preselectedProfileId)
+    }
+
+    private fun disposeCurrentEditors() {
+        (0 until myRoot.childCount).forEach { index ->
+            (myRoot.getChildAt(index) as MyNode).configurable.disposeUIResources()
+        }
+    }
+
+    fun validateProfiles(): ValidationInfo? {
+        val names = profileEditors().map { editor -> editor.displayName.trim() }
+        return when {
+            names.any(String::isBlank) ->
+                ValidationInfo("XMake build profile names must not be blank", tree)
+
+            names.distinct().size != names.size ->
+                ValidationInfo("XMake build profile names must be unique", tree)
+
+            else -> null
+        }
+    }
+
+    @Throws(ConfigurationException::class)
+    fun applyChanges() {
+        validateProfiles()?.let { validation -> throw ConfigurationException(validation.message) }
+        super.apply()
+        try {
+            project.xmakeBuildProfiles.replaceProfiles(profileEditors().map { editor -> editor.profile })
+        } catch (error: IllegalArgumentException) {
+            throw ConfigurationException(error.message.orEmpty())
+        }
+    }
+
+    override fun createActions(fromPopup: Boolean): List<AnAction> = listOf(
+        AddProfileAction(),
+        MyDeleteAction { selected -> myRoot.childCount > selected.size },
+    )
+
+    private fun preselectProfile(profileId: String?) {
+        val node = (0 until myRoot.childCount)
+            .asSequence()
+            .map { index -> myRoot.getChildAt(index) as MyNode }
+            .firstOrNull { node -> (node.configurable as XMakeBuildProfileEditor).profile.id == profileId }
+            ?: myRoot.getChildAt(0) as? MyNode
+        node?.let(::selectNodeInTree)
+    }
+
+    private fun profileEditors(): List<XMakeBuildProfileEditor> =
+        (0 until myRoot.childCount).map { index ->
+            val node = myRoot.getChildAt(index) as MyNode
+            node.configurable as XMakeBuildProfileEditor
+        }
+
+    private inner class AddProfileAction : DumbAwareAction(
+        "Add",
+        "Add XMake build profile",
+        AllIcons.General.Add,
+    ) {
+        override fun actionPerformed(event: AnActionEvent) {
+            val names = profileEditors().mapTo(mutableSetOf()) { editor -> editor.displayName.trim() }
+            val profile = XMakeBuildProfile.createDefault(project, XMakeBuildProfile.uniqueDefaultName(names))
+            val editor = XMakeBuildProfileEditor(project, profile, TREE_UPDATER)
+            val node = MyNode(editor)
+            (tree.model as DefaultTreeModel).insertNodeInto(node, myRoot, myRoot.childCount)
+            selectNodeInTree(node)
+        }
+    }
+}

--- a/src/main/kotlin/io/xmake/utils/info/XMakeInfoManager.kt
+++ b/src/main/kotlin/io/xmake/utils/info/XMakeInfoManager.kt
@@ -34,6 +34,8 @@ import com.intellij.util.messages.Topic
 import io.xmake.file.highlight.XMakeLuaLexer
 import io.xmake.project.profile.XMakeBuildProfile
 import io.xmake.project.profile.XMakeBuildProfileManager
+import io.xmake.project.profile.XMakeBuildProfileOptions
+import io.xmake.project.profile.xmakeBuildProfileOptionsCache
 import io.xmake.project.toolkit.ToolkitListener
 import io.xmake.run.command.configureBestEffort
 import io.xmake.run.command.executeInfoQuery
@@ -68,13 +70,17 @@ class XMakeInfoManager(
             ToolkitListener.TOPIC,
             object : ToolkitListener {
                 override fun toolkitsChanged() {
+                    project.xmakeBuildProfileOptionsCache.clear()
                     probeActiveBuildProfile()
                 }
             },
         )
         messageBusConnection.subscribe(
             XMakeBuildProfileManager.TOPIC,
-            XMakeBuildProfileManager.Listener { probeActiveBuildProfile() },
+            XMakeBuildProfileManager.Listener {
+                project.xmakeBuildProfileOptionsCache.clear()
+                probeActiveBuildProfile()
+            },
         )
         messageBusConnection.subscribe(
             VirtualFileManager.VFS_CHANGES,
@@ -87,6 +93,7 @@ class XMakeInfoManager(
                                 event.file?.name?.equals("xmake.lua", ignoreCase = true) == true
                     }
                     if (xmakeProjectAppearedOrChanged) probeActiveBuildProfile()
+                    if (xmakeProjectAppearedOrChanged) project.xmakeBuildProfileOptionsCache.clear()
                 }
             },
         )
@@ -106,17 +113,32 @@ class XMakeInfoManager(
     private suspend fun probeBuildProfile(profile: XMakeBuildProfile) {
         try {
             withContext(Dispatchers.IO) {
-                project.withProfileCommands(profile) {
-                    configureBestEffort(it)
-                    val parser = XMakeInfo()
-                    xmakeInfo.apply {
-                        architectures = parser.parseArchitectures(executeInfoQuery("architectures", it))
-                        buildModes = parser.parseBuildModes(executeInfoQuery("buildmodes", it))
-                        platforms = parser.parsePlatforms(executeInfoQuery("platforms", it))
-                        targets = parser.parseTargets(executeInfoQuery("targets", it))
-                        toolchains = parser.parseToolchains(executeInfoQuery("toolchains", it))
-                        apis = parser.parseApis(executeInfoQuery("apis", it))
-                    }
+                    project.withProfileCommands(profile) {
+                        configureBestEffort(it)
+                        val parser = XMakeInfo()
+                        val architectures = parser.parseArchitectures(executeInfoQuery("architectures", it))
+                        val buildModes = parser.parseBuildModes(executeInfoQuery("buildmodes", it))
+                        val platforms = parser.parsePlatforms(executeInfoQuery("platforms", it))
+                        val targets = parser.parseTargets(executeInfoQuery("targets", it))
+                        val toolchains = parser.parseToolchains(executeInfoQuery("toolchains", it))
+                        val apis = parser.parseApis(executeInfoQuery("apis", it))
+                        xmakeInfo.apply {
+                            this.architectures = architectures
+                            this.buildModes = buildModes
+                            this.platforms = platforms
+                            this.targets = targets
+                            this.toolchains = toolchains
+                            this.apis = apis
+                        }
+                        project.xmakeBuildProfileOptionsCache.put(
+                            profile,
+                            XMakeBuildProfileOptions(
+                                architectures = architectures,
+                                buildModes = buildModes,
+                                platforms = platforms,
+                                toolchains = toolchains,
+                            ),
+                        )
 
                     if (xmakeInfo.apis.isNotEmpty()) {
                         XMakeLuaLexer.updateApis(xmakeInfo.apis)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -155,6 +155,15 @@
             <add-to-group group-id="ExecutionTargets.Additional"/>
         </group>
 
+        <action id="XMake.RunToolbar.Build"
+                class="io.xmake.actions.RunToolbarBuildAction"
+                text="Build XMake Profile"
+                icon="AllIcons.Actions.Compile"
+                description="Build the selected XMake build profile.">
+            <add-to-group group-id="RunToolbarMainActionGroup"
+                          anchor="before"
+                          relative-to-action="compositeResumeGroup"/>
+        </action>
     </actions>
 
     <projectListeners>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -72,6 +72,12 @@
          https://github.com/centic9/IntelliJ-Action-IDs
     -->
     <actions>
+        <action id="XMake.EditBuildProfiles"
+                class="io.xmake.actions.EditXMakeBuildProfilesAction"
+                text="Edit XMake Build Profiles..."
+                icon="AllIcons.General.Settings"
+                description="Edit XMake build profiles."/>
+
         <group id="XMake.Menu" class="io.xmake.actions.XMakeMenuGroup" text="Xmake" popup="true" description="XMake menu">
             <add-to-group group-id="MainMenu"
                           anchor="after"
@@ -103,6 +109,7 @@
                     description="Clean target and object files."/>
             <separator/>
             <reference ref="editRunConfigurations"/>
+            <reference ref="XMake.EditBuildProfiles"/>
             <action id="XMake.CleanConfiguration"
                     class="io.xmake.actions.CleanConfigurationAction"
                     text="Clean Configuration"
@@ -141,6 +148,13 @@
             <separator/>
             <reference ref="XMake.UpdateCompileCommands"/>
         </group>
+
+        <group id="XMake.ExecutionTargets.Additional">
+            <separator/>
+            <reference ref="XMake.EditBuildProfiles"/>
+            <add-to-group group-id="ExecutionTargets.Additional"/>
+        </group>
+
     </actions>
 
     <projectListeners>


### PR DESCRIPTION
**Build profiles can now be edited in the IDE and built from the run toolbar.**

## What Changed

- Added a profile dialog with a master/detail editor. It supports add/remove, rename, active-profile preselection, blank and duplicate-name validation, atomic apply, and last-profile protection.
- Added a complete profile form for toolkit, platform, architecture, toolchain, build mode, working/build directories, Android NDK path, verbose output, and configure arguments.
- Platform, architecture, toolchain, and build-mode values are queried from `xmake` in the edited profile's context after a best-effort configure. Results are debounced, filtered by platform, checked against the visible form before application, cached by profile snapshot, and cleared after toolkit, profile, or `xmake.lua` changes.
- Added host-aware directory browsing, upload/download actions, and default working directories for local project roots, WSL paths, and stable SSH `.xmake` directories.
- Registered profile editing in the XMake menu and execution-target popup.
- Added a run-toolbar build action for the active target, with the sole profile as the fallback when only one exists. It is enabled only when an XMake run configuration is selected and its profile can execute.

*The new profile editor looks like this:*

<p align="center">
<img align="center" width="1027" height="716" alt="build-profile" src="https://github.com/user-attachments/assets/81b362e5-178e-4f81-b54c-114067715970" />
</p>

The profile list and editor form collect the build inputs shared by XMake run configurations.

*When the selected profile is executable, the run toolbar exposes the build action directly:*

<p align="center">
<img width="440" height="39" alt="build-profile-toolbar" src="https://github.com/user-attachments/assets/3d3fbef8-0ce7-4069-9f42-0402caef2d11" />
</p>

The action stays disabled until an XMake run configuration is selected and its active profile can execute.

## Why

- Profiles need to be visible and editable; otherwise users cannot inspect or correct the settings that all launches share.
- Valid platform and architecture choices depend on the project and selected toolkit. Querying `xmake` in the current profile avoids offering values that cannot be used together.
- A late query response must not overwrite the form after the user changes the toolkit or directory.
- Profiles are shared by multiple run configurations, so validation and application must happen as one transaction.
- Once a profile is executable, building should not require opening the run-configuration editor.
- WSL and SSH profiles need the same directory and transfer support as local profiles.

## Impact

*Users can create, inspect, validate, and switch complete XMake build contexts in IntelliJ, then start a correctly gated build from the run toolbar.*
