### PR TITLE
Fix XMake project creation

### DIFF
--- a/src/main/kotlin/io/xmake/actions/QuickStartAction.kt
+++ b/src/main/kotlin/io/xmake/actions/QuickStartAction.kt
@@ -26,6 +26,7 @@ import com.intellij.execution.process.ProcessEvent
 import com.intellij.execution.process.ProcessListener
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
@@ -68,50 +69,52 @@ class QuickStartAction : XMakeProjectAction() {
             val commandLine = GeneralCommandLine(toolkit.path, "create", "-P", ".")
                 .withWorkDirectory(workingDirectory)
 
-            try {
-                val process = commandLine.createProcess(toolkit)
-                val processHandler = KillableColoredProcessHandler(
-                    process,
-                    commandLine.commandLineString,
-                    Charsets.UTF_8,
-                )
-                processHandler.addProcessListener(object : ProcessListener {
-                    override fun processTerminated(event: ProcessEvent) {
-                        if (project.isDisposed) return
+            ApplicationManager.getApplication().executeOnPooledThread {
+                try {
+                    val process = commandLine.createProcess(toolkit)
+                    val processHandler = KillableColoredProcessHandler(
+                        process,
+                        commandLine.commandLineString,
+                        Charsets.UTF_8,
+                    )
+                    processHandler.addProcessListener(object : ProcessListener {
+                        override fun processTerminated(event: ProcessEvent) {
+                            if (project.isDisposed) return
 
-                        if (event.exitCode == 0) {
-                            NotificationGroupManager.getInstance()
-                                .getNotificationGroup("XMake.NotificationGroup")
-                                .createNotification("XMake project created successfully!", NotificationType.INFORMATION)
-                                .notify(project)
+                            if (event.exitCode == 0) {
+                                NotificationGroupManager.getInstance()
+                                    .getNotificationGroup("XMake.NotificationGroup")
+                                    .createNotification("XMake project created successfully!", NotificationType.INFORMATION)
+                                    .notify(project)
 
-                            ToolWindowManager.getInstance(project).invokeLater {
-                                if (project.isDisposed) return@invokeLater
+                                ToolWindowManager.getInstance(project).invokeLater {
+                                    if (project.isDisposed) return@invokeLater
 
-                                // Refresh VFS
-                                project.basePath?.let { path ->
-                                    val file = LocalFileSystem.getInstance().findFileByPath(path)
-                                    file?.let {
-                                        VfsUtil.markDirtyAndRefresh(false, true, true, it)
+                                    // Refresh VFS
+                                    project.basePath?.let { path ->
+                                        val file = LocalFileSystem.getInstance().findFileByPath(path)
+                                        file?.let {
+                                            VfsUtil.markDirtyAndRefresh(false, true, true, it)
+                                        }
+                                    }
+
+                                    // Show Tool Window
+                                    project.xmakeConsoleService.whenReady { console ->
+                                        console.showOutput()
                                     }
                                 }
-
-                                // Show Tool Window
-                                project.xmakeConsoleService.whenReady { console ->
-                                    console.showOutput()
-                                }
+                            } else {
+                                NotificationGroupManager.getInstance()
+                                    .getNotificationGroup("XMake.NotificationGroup")
+                                    .createNotification("Failed to create XMake project.", NotificationType.ERROR)
+                                    .notify(project)
                             }
-                        } else {
-                            NotificationGroupManager.getInstance()
-                                .getNotificationGroup("XMake.NotificationGroup")
-                                .createNotification("Failed to create XMake project.", NotificationType.ERROR)
-                                .notify(project)
                         }
-                    }
-                })
-                processHandler.startNotify()
-            } catch (e: Exception) {
-                notifyQuickStartFailure(project, "Failed to start xmake create: ${e.message}")
+                    })
+                    processHandler.startNotify()
+                } catch (e: Exception) {
+                    notifyQuickStartFailure(project, "Failed to start xmake create: ${e.message}")
+                }
             }
         }
     }

--- a/src/main/kotlin/io/xmake/actions/UpdateCMakeListsAction.kt
+++ b/src/main/kotlin/io/xmake/actions/UpdateCMakeListsAction.kt
@@ -15,7 +15,7 @@
  * Copyright (C) 2015-present, Xmake Open Source Community.
  *
  * @author      ruki
- * @file        UpdateCmakeListsAction.kt
+ * @file        UpdateCMakeListsAction.kt
  *
  */
 package io.xmake.actions
@@ -28,7 +28,7 @@ import io.xmake.run.command.xmakeExecutionService
 import io.xmake.utils.execute.fetchGeneratedFile
 import io.xmake.utils.execute.syncBeforeFetch
 
-class UpdateCmakeListsAction : XMakeCommandAction() {
+class UpdateCMakeListsAction : XMakeCommandAction() {
     override suspend fun execute(
         project: Project,
         console: XMakeConsole,

--- a/src/main/kotlin/io/xmake/project/wizard/XMakeProjectWizardStep.kt
+++ b/src/main/kotlin/io/xmake/project/wizard/XMakeProjectWizardStep.kt
@@ -192,12 +192,14 @@ class XMakeProjectWizardStep(parent: NewProjectWizardBaseStep) :
 
     override fun setupProject(project: Project) {
         if (context.isCreatingNewProject) {
+            val selectedToolkit = toolkit
+                ?: throw IllegalStateException("An XMake toolkit must be selected to create a project")
             val workingDirectory =
-                if (!toolkit!!.requiresBackend) File(contentEntryPath).path
+                if (!selectedToolkit.requiresBackend) File(contentEntryPath).path
                 else remoteContentEntryPath
 
             val generateDirectory =
-                if (!toolkit!!.requiresBackend) File("$contentEntryPath.tmpdir").path
+                if (!selectedToolkit.requiresBackend) File("$contentEntryPath.tmpdir").path
                 else remoteContentEntryPath
 
 
@@ -206,7 +208,7 @@ class XMakeProjectWizardStep(parent: NewProjectWizardBaseStep) :
             Log.info("working directory: $workingDirectory")
 
             val command = listOf(
-                "xmake",
+                selectedToolkit.path,
                 "create",
                 "-P",
                 generateDirectory,
@@ -216,12 +218,11 @@ class XMakeProjectWizardStep(parent: NewProjectWizardBaseStep) :
                 kindOptions[xmakeData?.kind]
             )
             val commandLine: GeneralCommandLine = GeneralCommandLine(command)
-//                .withWorkDirectory(workingDirectory)
                 .withCharset(Charsets.UTF_8)
 
             val output = try {
                 val result = runBlocking(Dispatchers.IO) {
-                    return@runBlocking runProcess(commandLine.createProcess(toolkit!!))
+                    return@runBlocking runProcess(commandLine.createProcess(selectedToolkit))
                 }
                 result.first.getOrDefault("")
             } catch (e: ProcessNotCreatedException) {
@@ -231,7 +232,7 @@ class XMakeProjectWizardStep(parent: NewProjectWizardBaseStep) :
 
             Log.info("XMake project creation output: $output")
 
-            with(toolkit!!) {
+            with(selectedToolkit) {
                 when (host.type) {
                     LOCAL -> {
                         val tempDirectory = File(generateDirectory)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -121,9 +121,9 @@
                     text="Quick Start"
                     icon="AllIcons.Actions.Lightning"
                     description="Quick start a new project."/>
-            <action id="XMake.UpdateCmakeLists"
-                    class="io.xmake.actions.UpdateCmakeListsAction"
-                    text="Update CmakeLists"
+            <action id="XMake.UpdateCMakeLists"
+                    class="io.xmake.actions.UpdateCMakeListsAction"
+                    text="Update CMakeLists"
                     icon="AllIcons.FileTypes.Csv"
                     description="Create or update the CMakeLists.txt.">
                 <keyboard-shortcut keymap="$default" first-keystroke="alt U" />


### PR DESCRIPTION
**Project creation now runs the XMake executable selected in the wizard, and Quick Start no longer freezes the UI while XMake starts.**

## What Changed

- The new-project wizard now captures the selected toolkit once, uses that toolkit's executable to create the project, and reports a clear setup error if no toolkit is selected.
- Quick Start launches `xmake create` on a background thread instead of the event dispatch thread. Success and failure notifications, project refresh, and console activation work as before.
- Corrected the capitalization of the CMake generation action, its implementation class, action ID, and menu label from `CmakeLists` to `CMakeLists`.

## Why

- Users select a toolkit in the wizard because they expect that installation to be used. Calling plain `xmake` depends on `PATH` and can invoke a different XMake executable.
- Continuing without a toolkit previously led to an unsafe null assertion. Failing early with a clear message is easier to understand and fix.
- Starting a process can block, so the IDE action should not do that work on the event dispatch thread.
- `CMake` is the official capitalization; using it consistently avoids a small but visible naming inconsistency.

## Impact

*New projects are created with the toolkit chosen in the wizard, and Quick Start stays responsive while XMake starts.*