### PR TITLE
Update plugin version to 1.4.23

### DIFF
--- a/change-notes.html
+++ b/change-notes.html
@@ -1,3 +1,15 @@
+<strong>1.4.23</strong>
+<ul>
+    <li>[NEW]: Add build profiles with management UI, execution targets, and toolbar build action</li>
+    <li>[IMPROVE]: Migrate build, run, debug, and metadata commands to build profiles</li>
+    <li>[IMPROVE]: Refactor toolkit hosts, scanning, and registrations</li>
+    <li>[IMPROVE]: Route builds through ProjectTaskManager</li>
+    <li>[IMPROVE]: Require IntelliJ Platform 2026.2 and JDK 25</li>
+    <li>[IMPROVE]: Use public IntelliJ Platform APIs for WSL, resources, and DAP</li>
+    <li>[FIX]: Fix SSH synchronization and remote working directories</li>
+    <li>[FIX]: Fix Problems tool window navigation and compiler diagnostics</li>
+    <li>[FIX]: Use the selected toolkit and keep Quick Start responsive during project creation</li>
+</ul>
 <strong>1.4.22</strong>
 <ul>
     <li>[FIX]: Update version</li>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pluginVersion=1.4.22
+pluginVersion=1.4.23
 pluginSinceBuild=262
 runIdeVersion=2026.2
 


### PR DESCRIPTION
**This prepares version `1.4.23` for release.**

## _What Changed_

- Bumped the plugin version from `1.4.22` to `1.4.23`.
- The next release requires IntelliJ Platform `2026.2` or later and JDK 25.

## _Why_

The minimum platform version is now `2026.2` because WSL execution, resource loading, and DAP integration use public APIs from that platform release.

## _Impact_

*This PR only changes release metadata.*